### PR TITLE
waitForPromises() accessible from other modules

### DIFF
--- a/Sources/Promises/Promise+Testing.swift
+++ b/Sources/Promises/Promise+Testing.swift
@@ -22,6 +22,6 @@ extension DispatchGroup {
 /// Waits for all scheduled promise blocks.
 /// - parameter timeout: Maximum time to wait.
 /// - returns: `true` if all promise blocks have completed before `timeout` and `false` otherwise.
-func waitForPromises(timeout: TimeInterval) -> Bool {
+public func waitForPromises(timeout: TimeInterval) -> Bool {
   return __FBLWaitForPromisesWithTimeout(timeout)
 }


### PR DESCRIPTION
Function waitForPromises() is not accessible from out of Promises module