### PR TITLE
Fix typo

### DIFF
--- a/g3doc/index.md
+++ b/g3doc/index.md
@@ -1533,7 +1533,7 @@ Swift:
 ```swift
 func asyncCall() -> Promise<Data> {
   let promise = doSomethingAsync()
-  promise.then(process)
+  promise.then(processData)
   return promise
 }
 ```
@@ -1559,7 +1559,7 @@ Swift:
 ```swift
 func asyncCall() -> Promise<Data> {
   let promise = doSomethingAsync()
-  return promise.then(process)
+  return promise.then(processData)
 }
 ```
 


### PR DESCRIPTION
I was reading the docs and I stumbled upon a code block difference between Swift and Obj-c where the docs refers to a function `processData` but in the Swift block it was only `process`. 