### PR TITLE
Increase waitForPromise timeout in Testing section

### DIFF
--- a/g3doc/index.md
+++ b/g3doc/index.md
@@ -1620,7 +1620,7 @@ func testExample() {
   let promise = Promise<Int> { 42 }
 
   // Assert.
-  XCTAssert(waitForPromises(timeout: 1))
+  XCTAssert(waitForPromises(timeout: 2))
   XCTAssertEqual(promise.value, 42)
   XCTAssertNil(promise.error)
 }


### PR DESCRIPTION
Hi, I've just used Promises in unit tests with Xcode 9.4.1 (MacBook Air 2016). I tried to use your example and it didn't work for me:
```swift
@testable import Promises

// ...
func testExample() {
  // Arrange & Act.
  let promise = Promise<Int> { 42 }

  // Assert.
  XCTAssert(waitForPromises(timeout: 1))
  XCTAssertEqual(promise.value, 42)
  XCTAssertNil(promise.error)
}
// ...
```
I got an assertion error on the waitForPromises line.
It is strange because there is no operations that could take up to 1 second. Anyway when I tried to increase the timeout to ```waitForPromises(timeout: 2)``` the test was passed.

Am I missing something here?
If this is expected behaviour, here is PR that updates the timeout in docs