### PR TITLE
Remove unnecessary block cast

### DIFF
--- a/Sources/Promises/Promise+Retry.swift
+++ b/Sources/Promises/Promise+Retry.swift
@@ -44,7 +44,7 @@ public func retry<Value>(
   _ work: @escaping () throws -> Promise<Value>
 ) -> Promise<Value> {
 #if (!swift(>=4.1) || (!swift(>=4.0) && swift(>=3.3)))
-  var predicateBlock: (( count: Int,  error: Error) -> ObjCBool)?
+  var predicateBlock: ((_ count: Int, _ error: Error) -> ObjCBool)?
   if predicate != nil {
     predicateBlock = { count, error -> ObjCBool in
       guard let predicate = predicate else { return true }


### PR DESCRIPTION
The block cast in Promise+Retry.swift isn't needed:

> "C typedefs of block types are imported as typealiass for Swift closures.
> 
> The primary result of this is that typedefs for blocks with a parameter of type BOOL are imported as closures with a parameter of type Bool (rather than ObjCBool as in the previous release). This matches the behavior of block parameters to imported Objective-C methods. (22013912)"
> 
> https://github.com/apple/swift/blob/master/CHANGELOG.md

The implementation for compilations with swift versions < 4.1 fail. This PR fixes #55 by removing the broken code.