### PR TITLE
Fix ObjCBool/Bool compile error

### DIFF
--- a/Promises.xcodeproj/project.pbxproj
+++ b/Promises.xcodeproj/project.pbxproj
@@ -1552,7 +1552,6 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
 				TARGET_NAME = PromisesTestHelpers;
 			};
 			name = Debug;
@@ -1572,7 +1571,6 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
 				TARGET_NAME = PromisesTestHelpers;
 			};
 			name = Release;
@@ -1592,7 +1590,6 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
 				TARGET_NAME = Promises;
 			};
 			name = Debug;
@@ -1612,7 +1609,6 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
 				TARGET_NAME = Promises;
 			};
 			name = Release;
@@ -1767,6 +1763,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				USE_HEADERMAP = NO;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
@@ -1814,6 +1811,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				USE_HEADERMAP = NO;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;

--- a/Sources/Promises/Promise+Retry.swift
+++ b/Sources/Promises/Promise+Retry.swift
@@ -43,7 +43,7 @@ public func retry<Value>(
   condition predicate: ((_ count: Int, _ error: Error) -> Bool)? = nil,
   _ work: @escaping () throws -> Promise<Value>
 ) -> Promise<Value> {
-#if swift(>=4.1)
+#if (swift(>=4.1) || (!swift(>=4.0) && swift(>=3.3)))
   let predicateBlock = predicate
 #else
   var predicateBlock: ((_ count: Int, _ error: Error) -> ObjCBool)?
@@ -53,7 +53,7 @@ public func retry<Value>(
       return ObjCBool(predicate(count, error))
     }
   }
-#endif  // swift(>=4.1)
+#endif  // (swift(>=4.1) || (!swift(>=4.0) && swift(>=3.3)))
   let objCPromise = Promise<Value>.ObjCPromise<AnyObject>.__onQueue(
     queue,
     attempts: count,


### PR DESCRIPTION
Fixes build with Swift 4.0 and 3.2 (Xcode 9.0) and 4.1 and 3.3 (Xcode 9.4).

Also moves the Swift version from Promises and PromisesTests to the Xcode project itself.