### PR TITLE
Added cleanup of delayed reject/resolve to avoid code execution after the tests for delay are complete.

### DIFF
--- a/Tests/FBLPromisesTests/FBLPromise+DelayTests.m
+++ b/Tests/FBLPromisesTests/FBLPromise+DelayTests.m
@@ -37,7 +37,7 @@
     XCTAssertEqualObjects(value, @42);
     return value;
   }];
-  XCTestExpectation *delayedRejectCleanup = [self expectationWithDescription:@"delayedRejectCleanup"];
+  XCTestExpectation *delayedRejectCleanup = [self expectationWithDescription:@""];
   FBLDelay(1, ^{
     [promise reject:[NSError errorWithDomain:FBLPromiseErrorDomain code:42 userInfo:nil]];
     [delayedRejectCleanup fulfill];
@@ -55,7 +55,7 @@
 - (void)testPromiseDelayFail {
   // Act.
   FBLPromise<NSNumber *> *promise = [[FBLPromise resolvedWith:@42] delay:1];
-  XCTestExpectation *delayedResolveCleanup = [self expectationWithDescription:@"delayedResolveCleanup"];
+  XCTestExpectation *delayedResolveCleanup = [self expectationWithDescription:@""];
   FBLDelay(1, ^{
     [delayedResolveCleanup fulfill];
   });


### PR DESCRIPTION
This should address #90. I verified it within my ["leaks enabled" branch](https://github.com/grigorye/promises/commits/feature/ge-leaks).

I'm not sure this is the best solution, as it effectively results in 1 sec delay in each of the cases. So feel free to ignore it.