### PR TITLE
Adds a test_host for executing Promises tests on real iOS devices.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,12 @@ os: osx
 osx_image: xcode10.1
 language: objective-c
 install: true
-addons:
-  homebrew:
-    taps: homebrew/cask-versions
-    casks: java8
 before_install:
-    - brew update
-    - brew install bazel
+    - curl -o ~/tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.22.0/bazel-0.22.0-installer-darwin-x86_64.sh
+    - chmod +x bazel.sh
+    - ./bazel.sh --user
+    - export PATH="$PATH:$HOME/bin"
 script:
     - bazel shutdown
+    - bazel version
     - bazel test Tests --nokeep_state_after_build --spawn_strategy=standalone --genrule_strategy=standalone --test_strategy=standalone --noshow_progress --noshow_loading_progress --verbose_failures --test_verbose_timeout_warnings --test_output=errors

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ osx_image: xcode10.1
 language: objective-c
 install: true
 before_install:
+    - bazel_version=0.22.0
     - bazel_script=/tmp/bazel.sh
-    - curl -L https://github.com/bazelbuild/bazel/releases/download/0.22.0/bazel-0.22.0-installer-darwin-x86_64.sh -o $bazel_script
+    - curl -L https://github.com/bazelbuild/bazel/releases/download/$bazel_version/bazel-$bazel_version-installer-darwin-x86_64.sh -o $bazel_script
     - chmod +x $bazel_script
     - sh $bazel_script --user
     - export PATH="$PATH:$HOME/bin"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ osx_image: xcode10.1
 language: objective-c
 install: true
 before_install:
-    - curl -o ~/tmp/bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.22.0/bazel-0.22.0-installer-darwin-x86_64.sh
-    - chmod +x bazel.sh
-    - ./bazel.sh --user
+    - bazel_script=/tmp/bazel.sh
+    - curl -L https://github.com/bazelbuild/bazel/releases/download/0.22.0/bazel-0.22.0-installer-darwin-x86_64.sh -o $bazel_script
+    - chmod +x $bazel_script
+    - sh $bazel_script --user
     - export PATH="$PATH:$HOME/bin"
 script:
     - bazel shutdown

--- a/BUILD
+++ b/BUILD
@@ -4,7 +4,7 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application", "ios_unit_test")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 OBJC_COPTS = [
@@ -18,6 +18,8 @@ OBJC_COPTS = [
 SWIFT_COPTS = [
     "-wmo",
 ]
+
+MINIMUM_OS_VERSION = "8.0"
 
 swift_library(
     name = "Promises",
@@ -83,8 +85,8 @@ objc_library(
 
 ios_unit_test(
     name = "Tests",
-    minimum_os_version = "8.0",
-    test_host = "@build_bazel_rules_apple//apple/testing/default_host/ios",
+    minimum_os_version = MINIMUM_OS_VERSION,
+    test_host = ":TestHostApp",
     deps = [
         ":FBLPromisesInteroperabilityTests",
         ":FBLPromisesPerformanceTests",
@@ -93,6 +95,26 @@ ios_unit_test(
         ":PromisesPerformanceTests",
         ":PromisesTests",
     ],
+)
+
+ios_application(
+    name = "TestHostApp",
+    testonly = 1,
+    bundle_id = "com.google.promises.Tests.TestHost",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = ["Promises.xcodeproj/TestHost_Info.plist"],
+    minimum_os_version = MINIMUM_OS_VERSION,
+    deps = [":TestHost"],
+)
+
+swift_library(
+    name = "TestHost",
+    testonly = 1,
+    srcs = glob(["Tests/TestHost/*.swift"]),
+    copts = SWIFT_COPTS,
 )
 
 swift_library(

--- a/BUILD
+++ b/BUILD
@@ -105,15 +105,21 @@ ios_application(
         "iphone",
         "ipad",
     ],
-    infoplists = ["Promises.xcodeproj/TestHost_Info.plist"],
+    infoplists = [
+        "Promises.xcodeproj/TestHost_Info.plist",
+    ],
     minimum_os_version = MINIMUM_OS_VERSION,
-    deps = [":TestHost"],
+    deps = [
+        ":TestHost",
+    ],
 )
 
 swift_library(
     name = "TestHost",
     testonly = 1,
-    srcs = glob(["Tests/TestHost/*.swift"]),
+    srcs = glob([
+        "Tests/TestHost/*.swift",
+    ]),
     copts = SWIFT_COPTS,
 )
 

--- a/BUILD
+++ b/BUILD
@@ -100,7 +100,7 @@ ios_unit_test(
 ios_application(
     name = "TestHostApp",
     testonly = 1,
-    bundle_id = "com.google.promises.Tests.TestHost",
+    bundle_id = "com.google.promises.TestHost",
     families = [
         "iphone",
         "ipad",

--- a/Promises.tulsiproj/Configs/Promises.tulsigen
+++ b/Promises.tulsiproj/Configs/Promises.tulsigen
@@ -1,0 +1,69 @@
+{
+  "sourceFilters" : [
+    "Sources",
+    "Sources/FBLPromises",
+    "Sources/FBLPromises/DotSyntax",
+    "Sources/FBLPromises/include",
+    "Sources/FBLPromises/include/DotSyntax",
+    "Sources/FBLPromisesTestHelpers",
+    "Sources/FBLPromisesTestHelpers/include",
+    "Sources/Promises",
+    "Sources/PromisesTestHelpers",
+    "Tests",
+    "Tests/FBLPromisesInteroperabilityTests",
+    "Tests/FBLPromisesPerformanceTests",
+    "Tests/FBLPromisesTests",
+    "Tests/PromisesInteroperabilityTests",
+    "Tests/PromisesPerformanceTests",
+    "Tests/PromisesTests",
+    "Tests/TestHost"
+  ],
+  "buildTargets" : [
+    "//:FBLPromises",
+    "//:Promises",
+    "//:TestHostApp",
+    "//:Tests"
+  ],
+  "projectName" : "Promises",
+  "optionSet" : {
+    "BazelBuildOptionsDebug" : {
+      "p" : "$(inherited)"
+    },
+    "BazelBuildStartupOptionsRelease" : {
+      "p" : "$(inherited)"
+    },
+    "LaunchActionPreActionScript" : {
+      "p" : "$(inherited)"
+    },
+    "BazelBuildOptionsRelease" : {
+      "p" : "$(inherited)"
+    },
+    "EnvironmentVariables" : {
+      "p" : "$(inherited)"
+    },
+    "BuildActionPreActionScript" : {
+      "p" : "$(inherited)"
+    },
+    "CommandlineArguments" : {
+      "p" : "$(inherited)"
+    },
+    "TestActionPreActionScript" : {
+      "p" : "$(inherited)"
+    },
+    "TestActionPostActionScript" : {
+      "p" : "$(inherited)"
+    },
+    "BuildActionPostActionScript" : {
+      "p" : "$(inherited)"
+    },
+    "BazelBuildStartupOptionsDebug" : {
+      "p" : "$(inherited)"
+    },
+    "LaunchActionPostActionScript" : {
+      "p" : "$(inherited)"
+    }
+  },
+  "additionalFilePaths" : [
+    "BUILD"
+  ]
+}

--- a/Promises.tulsiproj/Configs/Promises.tulsigen
+++ b/Promises.tulsiproj/Configs/Promises.tulsigen
@@ -21,7 +21,6 @@
   "buildTargets" : [
     "//:FBLPromises",
     "//:Promises",
-    "//:TestHostApp",
     "//:Tests"
   ],
   "projectName" : "Promises",

--- a/Promises.tulsiproj/project.tulsiconf
+++ b/Promises.tulsiproj/project.tulsiconf
@@ -1,0 +1,14 @@
+{
+  "configDefaults" : {
+    "optionSet" : {
+      "ProjectPrioritizesSwift" : {
+        "p" : "YES"
+      }
+    }
+  },
+  "projectName" : "Promises",
+  "packages" : [
+    ""
+  ],
+  "workspaceRoot" : ".."
+}

--- a/Promises.xcodeproj/TestHost_Info.plist
+++ b/Promises.xcodeproj/TestHost_Info.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Tests/TestHost/AppDelegate.swift
+++ b/Tests/TestHost/AppDelegate.swift
@@ -1,0 +1,28 @@
+// Copyright 2018 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+  var window: UIWindow?
+
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  ) -> Bool {
+    return true
+  }
+}

--- a/Tests/TestHost/AppDelegate.swift
+++ b/Tests/TestHost/AppDelegate.swift
@@ -16,9 +16,6 @@ import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-  var window: UIWindow?
-
   func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.12.0",
+    tag = "0.13.0",
 )
 
 load(
@@ -25,5 +25,5 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 http_file(
     name = "xctestrunner",
     executable = 1,
-    urls = ["https://github.com/google/xctestrunner/releases/download/0.2.5/ios_test_runner.par"],
+    urls = ["https://github.com/google/xctestrunner/releases/download/0.2.6/ios_test_runner.par"],
 )


### PR DESCRIPTION
- Adds a test_host for executing Promises tests on real iOS devices.
- Updates Bazel Apple rules to 0.13.0 and xctestrunner to 0.2.6.
- Updates Travis-CI to install bazel version 0.22.0 manually rather than through Homebrew.