### PR TITLE
Changed "Runpath Search Paths" build setting to @executable_path/Frameworks

### DIFF
--- a/Promises.xcodeproj/project.pbxproj
+++ b/Promises.xcodeproj/project.pbxproj
@@ -1331,7 +1331,6 @@
 					"$(BUILT_PRODUCTS_DIR)/PromisesTestHelpers.framework/Headers",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/FBLPromisesInteroperabilityTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
@@ -1357,7 +1356,6 @@
 					"$(BUILT_PRODUCTS_DIR)/PromisesTestHelpers.framework/Headers",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/FBLPromisesInteroperabilityTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
@@ -1382,7 +1380,6 @@
 					"$(SRCROOT)/Sources/FBLPromises/include",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/FBLPromisesPerformanceTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
@@ -1406,7 +1403,6 @@
 					"$(SRCROOT)/Sources/FBLPromises/include",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/FBLPromisesPerformanceTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
@@ -1424,7 +1420,6 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/PromisesTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -1442,7 +1437,6 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/PromisesTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -1466,7 +1460,6 @@
 					"$(SRCROOT)/Sources/FBLPromises/include",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/FBLPromisesTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
@@ -1490,7 +1483,6 @@
 					"$(SRCROOT)/Sources/FBLPromises/include",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/FBLPromisesTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
@@ -1508,7 +1500,6 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/PromisesPerformanceTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -1526,7 +1517,6 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/PromisesPerformanceTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -1544,7 +1534,6 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/PromisesInteroperabilityTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -1562,7 +1551,6 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/PromisesInteroperabilityTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -1580,7 +1568,6 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/PromisesTestHelpers_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1599,7 +1586,6 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/PromisesTestHelpers_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1619,7 +1605,6 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/Promises_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1640,7 +1625,6 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/Promises_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1666,7 +1650,6 @@
 					"$(SRCROOT)/Sources/FBLPromises/include",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/FBLPromisesTestHelpers_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MODULEMAP_FILE = "$(SRCROOT)/Sources/FBLPromisesTestHelpers/include/framework.modulemap";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -1694,7 +1677,6 @@
 					"$(SRCROOT)/Sources/FBLPromises/include",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/FBLPromisesTestHelpers_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MODULEMAP_FILE = "$(SRCROOT)/Sources/FBLPromisesTestHelpers/include/framework.modulemap";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -1722,7 +1704,6 @@
 					"$(SRCROOT)/Sources/FBLPromises/include",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/FBLPromises_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MODULEMAP_FILE = "$(SRCROOT)/Sources/FBLPromises/include/framework.modulemap";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -1750,7 +1731,6 @@
 					"$(SRCROOT)/Sources/FBLPromises/include",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/FBLPromises_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MODULEMAP_FILE = "$(SRCROOT)/Sources/FBLPromises/include/framework.modulemap";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -1801,6 +1781,8 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1849,6 +1831,8 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";

--- a/Promises.xcodeproj/project.pbxproj
+++ b/Promises.xcodeproj/project.pbxproj
@@ -1580,7 +1580,7 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/PromisesTestHelpers_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1599,7 +1599,7 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/PromisesTestHelpers_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1619,7 +1619,7 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/Promises_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1640,7 +1640,7 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/Promises_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1666,7 +1666,7 @@
 					"$(SRCROOT)/Sources/FBLPromises/include",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/FBLPromisesTestHelpers_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MODULEMAP_FILE = "$(SRCROOT)/Sources/FBLPromisesTestHelpers/include/framework.modulemap";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -1694,7 +1694,7 @@
 					"$(SRCROOT)/Sources/FBLPromises/include",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/FBLPromisesTestHelpers_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MODULEMAP_FILE = "$(SRCROOT)/Sources/FBLPromisesTestHelpers/include/framework.modulemap";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -1722,7 +1722,7 @@
 					"$(SRCROOT)/Sources/FBLPromises/include",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/FBLPromises_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MODULEMAP_FILE = "$(SRCROOT)/Sources/FBLPromises/include/framework.modulemap";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -1750,7 +1750,7 @@
 					"$(SRCROOT)/Sources/FBLPromises/include",
 				);
 				INFOPLIST_FILE = Promises.xcodeproj/FBLPromises_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MODULEMAP_FILE = "$(SRCROOT)/Sources/FBLPromises/include/framework.modulemap";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";


### PR DESCRIPTION
The previous value - `$(TOOLCHAIN_DIR)/usr/lib/swift/macosx` - caused the built framework binary to have the following `otool -l` output:

```
Load command 24
          cmd LC_RPATH
      cmdsize 112
         path /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx (offset 12)
```

This caused errors during binary upload to the app store. In particular, App Store Connect sent an e-mail with the following error message:

```
Dear Developer,

We identified one or more issues with a recent delivery for your app, "TheApp". Please correct the following issues, then upload again.

Invalid Bundle - One or more dynamic libraries that are referenced by your app are not present in the dylib search path.

Invalid Bundle - The app uses Swift, but one of the binaries could not link to it because it wasn't found. Check that the app bundles correctly embed Swift standard libraries using the "Always Embed Swift Standard Libraries" build setting, and that each binary which uses Swift has correct search paths to the embedded Swift standard libraries using the "Runpath Search Paths" build setting.
```

This same error can be also seen by making Xcode archive export while having app thinning and bitcode compilation enabled:

```
$ cat export_options.plist 
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>method</key>
    <string>development</string>
    <key>thinning</key>
    <string>iPhone7,1</string>
    <key>provisioningProfiles</key>
    <dict>
        <key>xxx</key>
        <string>yyy</string>
    </dict>
</dict>
</plist>
```

```
xcodebuild -exportArchive -exportOptionsPlist  export_options.plist  -archivePath /path/to/archive.xcarchive  -exportPath exported-archive
```

Output:

```
error: exportArchive: ipatool failed with an exception: #<CmdSpec::NonZeroExcitException: Command exited with pid 55583 exit 1:
/Applications/Xcode.app/Contents/Developer/usr/bin/bitcode-build-tool -v -t /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin -L /var/folders/zj/sn8dz1wx4y7c03lc6tvd4zd00000gn/T/ipatool20190215-54450-15zcqlz/thinned-out/armv7/Payload/StandaloneApp.app/Frameworks/FBLPromises.framework --sdk /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.1.sdk -o /var/folders/zj/sn8dz1wx4y7c03lc6tvd4zd00000gn/T/ipatool20190215-54450-15zcqlz/thinned-out/armv7/Payload/StandaloneApp.app/Frameworks/Promises.framework/Promises --generate-dsym /var/folders/zj/sn8dz1wx4y7c03lc6tvd4zd00000gn/T/ipatool20190215-54450-15zcqlz/thinned-out/armv7/Payload/StandaloneApp.app/Frameworks/Promises.framework/Promises.dSYM --strip-swift-symbols /var/folders/zj/sn8dz1wx4y7c03lc6tvd4zd00000gn/T/ipatool20190215-54450-15zcqlz/thinned-in/armv7/Payload/StandaloneApp.app/Frameworks/Promises.framework/Promises
```

I contacted Apple through DTS program, and their recommendation was to use `@executable_path/Frameworks` as value for the `Runpath Search Paths` build setting. 

