### PR TITLE
Update Xcode project to use default Swift compilation mode

### DIFF
--- a/Promises.xcodeproj/project.pbxproj
+++ b/Promises.xcodeproj/project.pbxproj
@@ -1334,7 +1334,6 @@
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_VERSION = 4.2;
 				TARGET_NAME = FBLPromisesInteroperabilityTests;
 			};
@@ -1359,7 +1358,6 @@
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_VERSION = 4.2;
 				TARGET_NAME = FBLPromisesInteroperabilityTests;
 			};
@@ -1383,7 +1381,6 @@
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
-				SWIFT_COMPILATION_MODE = wholemodule;
 				TARGET_NAME = FBLPromisesPerformanceTests;
 			};
 			name = Debug;
@@ -1406,7 +1403,6 @@
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
-				SWIFT_COMPILATION_MODE = wholemodule;
 				TARGET_NAME = FBLPromisesPerformanceTests;
 			};
 			name = Release;
@@ -1422,7 +1418,6 @@
 				INFOPLIST_FILE = Promises.xcodeproj/PromisesTests_Info.plist;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_VERSION = 4.2;
 				TARGET_NAME = PromisesTests;
 			};
@@ -1439,7 +1434,6 @@
 				INFOPLIST_FILE = Promises.xcodeproj/PromisesTests_Info.plist;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_VERSION = 4.2;
 				TARGET_NAME = PromisesTests;
 			};
@@ -1463,7 +1457,6 @@
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
-				SWIFT_COMPILATION_MODE = wholemodule;
 				TARGET_NAME = FBLPromisesTests;
 			};
 			name = Debug;
@@ -1486,7 +1479,6 @@
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
-				SWIFT_COMPILATION_MODE = wholemodule;
 				TARGET_NAME = FBLPromisesTests;
 			};
 			name = Release;
@@ -1502,7 +1494,6 @@
 				INFOPLIST_FILE = Promises.xcodeproj/PromisesPerformanceTests_Info.plist;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_VERSION = 4.2;
 				TARGET_NAME = PromisesPerformanceTests;
 			};
@@ -1519,7 +1510,6 @@
 				INFOPLIST_FILE = Promises.xcodeproj/PromisesPerformanceTests_Info.plist;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_VERSION = 4.2;
 				TARGET_NAME = PromisesPerformanceTests;
 			};
@@ -1536,7 +1526,6 @@
 				INFOPLIST_FILE = Promises.xcodeproj/PromisesInteroperabilityTests_Info.plist;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_VERSION = 4.2;
 				TARGET_NAME = PromisesInteroperabilityTests;
 			};
@@ -1553,7 +1542,6 @@
 				INFOPLIST_FILE = Promises.xcodeproj/PromisesInteroperabilityTests_Info.plist;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME)";
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_VERSION = 4.2;
 				TARGET_NAME = PromisesInteroperabilityTests;
 			};
@@ -1610,7 +1598,6 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_COMPILATION_MODE = wholemodule;
 				TARGET_NAME = Promises;
 			};
 			name = Debug;
@@ -1630,7 +1617,6 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_COMPILATION_MODE = wholemodule;
 				TARGET_NAME = Promises;
 			};
 			name = Release;
@@ -1657,7 +1643,6 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_COMPILATION_MODE = wholemodule;
 				TARGET_NAME = FBLPromisesTestHelpers;
 			};
 			name = Debug;
@@ -1684,7 +1669,6 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_COMPILATION_MODE = wholemodule;
 				TARGET_NAME = FBLPromisesTestHelpers;
 			};
 			name = Release;
@@ -1711,7 +1695,6 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_COMPILATION_MODE = wholemodule;
 				TARGET_NAME = FBLPromises;
 			};
 			name = Debug;
@@ -1738,7 +1721,6 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_COMPILATION_MODE = wholemodule;
 				TARGET_NAME = FBLPromises;
 			};
 			name = Release;
@@ -1836,7 +1818,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.2;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				USE_HEADERMAP = NO;


### PR DESCRIPTION
Follow-on to https://github.com/google/promises/pull/98 to bring Xcode-based build options in line with the Bazel config.