### PR TITLE
Fix Xcode Swift 5 conversion warning

### DIFF
--- a/PromisesSwift.podspec
+++ b/PromisesSwift.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target  = '10.10'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
+  s.swift_version = '5.0'
 
   s.module_name = 'Promises'
   s.source_files = "Sources/#{s.module_name}/*.{swift}"


### PR DESCRIPTION
After the update to Swift 5 the `swift_version` was deleted from _PromisesSwift.podspec_ (70c337e196c81f795eedb5d7a42cf966f07cdc3d). But now, Xcode keeps showing the _"Conversion to Swift 5 is available"_ warning:

![Screenshot 2019-07-07 at 19 03 40](https://user-images.githubusercontent.com/4272387/60772011-1ebfeb00-a0f0-11e9-8e2b-9a7558b32051.png)

Putting it back will make the warning disappear. 