### PR TITLE
Make FBLPromise.pendingObjects access threadsafe

### DIFF
--- a/Sources/FBLPromises/FBLPromise+Testing.m
+++ b/Sources/FBLPromises/FBLPromise+Testing.m
@@ -40,7 +40,6 @@ BOOL FBLWaitForPromisesWithTimeout(NSTimeInterval timeout) {
 @dynamic isPending;
 @dynamic isFulfilled;
 @dynamic isRejected;
-@dynamic pendingObjects;
 @dynamic value;
 @dynamic error;
 

--- a/Sources/FBLPromises/FBLPromise+Testing.m
+++ b/Sources/FBLPromises/FBLPromise+Testing.m
@@ -40,7 +40,6 @@ BOOL FBLWaitForPromisesWithTimeout(NSTimeInterval timeout) {
 @dynamic isPending;
 @dynamic isFulfilled;
 @dynamic isRejected;
-@dynamic isPendingObjectsEmpty;
 @dynamic value;
 @dynamic error;
 

--- a/Sources/FBLPromises/FBLPromise+Testing.m
+++ b/Sources/FBLPromises/FBLPromise+Testing.m
@@ -40,6 +40,7 @@ BOOL FBLWaitForPromisesWithTimeout(NSTimeInterval timeout) {
 @dynamic isPending;
 @dynamic isFulfilled;
 @dynamic isRejected;
+@dynamic isPendingObjectsEmpty;
 @dynamic value;
 @dynamic error;
 

--- a/Sources/FBLPromises/FBLPromise.m
+++ b/Sources/FBLPromises/FBLPromise.m
@@ -204,6 +204,16 @@ static dispatch_queue_t gFBLPromiseDefaultDispatchQueue;
   }
 }
 
+- (BOOL)isPendingObjectsEmpty {
+  @synchronized(self) {
+    if (_state == FBLPromiseStatePending && _pendingObjects) {
+      return [_pendingObjects count] == 0;
+    }
+
+    return TRUE;
+  }
+}
+
 - (void)observeOnQueue:(dispatch_queue_t)queue
                fulfill:(FBLPromiseOnFulfillBlock)onFulfill
                 reject:(FBLPromiseOnRejectBlock)onReject {

--- a/Sources/FBLPromises/FBLPromise.m
+++ b/Sources/FBLPromises/FBLPromise.m
@@ -191,7 +191,7 @@ static dispatch_queue_t gFBLPromiseDefaultDispatchQueue;
   }
 }
 
-- (void)__addPendingObject:(id)object {
+- (void)addPendingObject:(id)object {
   @synchronized(self) {
     if (_state == FBLPromiseStatePending) {
       if (!_pendingObjects) {

--- a/Sources/FBLPromises/FBLPromise.m
+++ b/Sources/FBLPromises/FBLPromise.m
@@ -191,23 +191,13 @@ static dispatch_queue_t gFBLPromiseDefaultDispatchQueue;
   }
 }
 
-- (NSMutableSet *__nullable)pendingObjects {
+- (void)__addPendingObject:(id)object {
   @synchronized(self) {
     if (_state == FBLPromiseStatePending) {
       if (!_pendingObjects) {
         _pendingObjects = [[NSMutableSet alloc] init];
       }
-    }
-    return _pendingObjects;
-  }
-}
-
-- (void)addToPendingObjects:(id)object {
-  NSMutableSet *set = [self pendingObjects];
-
-  if (set) {
-    @synchronized(set) {
-      [set addObject:object];
+      [_pendingObjects addObject:object];
     }
   }
 }

--- a/Sources/FBLPromises/FBLPromise.m
+++ b/Sources/FBLPromises/FBLPromise.m
@@ -204,16 +204,6 @@ static dispatch_queue_t gFBLPromiseDefaultDispatchQueue;
   }
 }
 
-- (BOOL)isPendingObjectsEmpty {
-  @synchronized(self) {
-    if (_state == FBLPromiseStatePending && _pendingObjects) {
-      return [_pendingObjects count] == 0;
-    }
-
-    return TRUE;
-  }
-}
-
 - (void)observeOnQueue:(dispatch_queue_t)queue
                fulfill:(FBLPromiseOnFulfillBlock)onFulfill
                 reject:(FBLPromiseOnRejectBlock)onReject {

--- a/Sources/FBLPromises/FBLPromise.m
+++ b/Sources/FBLPromises/FBLPromise.m
@@ -202,6 +202,16 @@ static dispatch_queue_t gFBLPromiseDefaultDispatchQueue;
   }
 }
 
+- (void)addToPendingObjects:(id)object {
+  NSMutableSet *set = [self pendingObjects];
+
+  if (set) {
+    @synchronized(set) {
+      [set addObject:object];
+    }
+  }
+}
+
 - (void)observeOnQueue:(dispatch_queue_t)queue
                fulfill:(FBLPromiseOnFulfillBlock)onFulfill
                 reject:(FBLPromiseOnRejectBlock)onReject {

--- a/Sources/FBLPromises/FBLPromise.m
+++ b/Sources/FBLPromises/FBLPromise.m
@@ -192,6 +192,8 @@ static dispatch_queue_t gFBLPromiseDefaultDispatchQueue;
 }
 
 - (void)addPendingObject:(id)object {
+  NSParameterAssert(object);
+  
   @synchronized(self) {
     if (_state == FBLPromiseStatePending) {
       if (!_pendingObjects) {

--- a/Sources/FBLPromises/include/FBLPromise+Testing.h
+++ b/Sources/FBLPromises/include/FBLPromise+Testing.h
@@ -41,12 +41,6 @@ FOUNDATION_EXTERN BOOL FBLWaitForPromisesWithTimeout(NSTimeInterval timeout) NS_
 @property(nonatomic, readonly) BOOL isRejected NS_REFINED_FOR_SWIFT;
 
 /**
- Set of arbitrary objects to keep strongly while the promise is pending.
- Becomes nil after the promise has been resolved.
- */
-@property(nonatomic, readonly, nullable) NSMutableSet *pendingObjects NS_REFINED_FOR_SWIFT;
-
-/**
  Value the promise was fulfilled with.
  Can be nil if the promise is still pending, was resolved with nil or after it has been rejected.
  */

--- a/Sources/FBLPromises/include/FBLPromise+Testing.h
+++ b/Sources/FBLPromises/include/FBLPromise+Testing.h
@@ -39,7 +39,6 @@ FOUNDATION_EXTERN BOOL FBLWaitForPromisesWithTimeout(NSTimeInterval timeout) NS_
 @property(nonatomic, readonly) BOOL isPending NS_REFINED_FOR_SWIFT;
 @property(nonatomic, readonly) BOOL isFulfilled NS_REFINED_FOR_SWIFT;
 @property(nonatomic, readonly) BOOL isRejected NS_REFINED_FOR_SWIFT;
-@property(nonatomic, readonly) BOOL isPendingObjectsEmpty NS_REFINED_FOR_SWIFT;
 
 /**
  Value the promise was fulfilled with.

--- a/Sources/FBLPromises/include/FBLPromise+Testing.h
+++ b/Sources/FBLPromises/include/FBLPromise+Testing.h
@@ -47,6 +47,11 @@ FOUNDATION_EXTERN BOOL FBLWaitForPromisesWithTimeout(NSTimeInterval timeout) NS_
 @property(nonatomic, readonly, nullable) NSMutableSet *pendingObjects NS_REFINED_FOR_SWIFT;
 
 /**
+ Add an object to the set of pending objects to keep strongly while the promise is pending.
+ */
+- (void)addToPendingObjects:(id)object NS_REFINED_FOR_SWIFT;
+
+/**
  Value the promise was fulfilled with.
  Can be nil if the promise is still pending, was resolved with nil or after it has been rejected.
  */

--- a/Sources/FBLPromises/include/FBLPromise+Testing.h
+++ b/Sources/FBLPromises/include/FBLPromise+Testing.h
@@ -47,11 +47,6 @@ FOUNDATION_EXTERN BOOL FBLWaitForPromisesWithTimeout(NSTimeInterval timeout) NS_
 @property(nonatomic, readonly, nullable) NSMutableSet *pendingObjects NS_REFINED_FOR_SWIFT;
 
 /**
- Add an object to the set of pending objects to keep strongly while the promise is pending.
- */
-- (void)addToPendingObjects:(id)object NS_REFINED_FOR_SWIFT;
-
-/**
  Value the promise was fulfilled with.
  Can be nil if the promise is still pending, was resolved with nil or after it has been rejected.
  */

--- a/Sources/FBLPromises/include/FBLPromise+Testing.h
+++ b/Sources/FBLPromises/include/FBLPromise+Testing.h
@@ -39,6 +39,7 @@ FOUNDATION_EXTERN BOOL FBLWaitForPromisesWithTimeout(NSTimeInterval timeout) NS_
 @property(nonatomic, readonly) BOOL isPending NS_REFINED_FOR_SWIFT;
 @property(nonatomic, readonly) BOOL isFulfilled NS_REFINED_FOR_SWIFT;
 @property(nonatomic, readonly) BOOL isRejected NS_REFINED_FOR_SWIFT;
+@property(nonatomic, readonly) BOOL isPendingObjectsEmpty NS_REFINED_FOR_SWIFT;
 
 /**
  Value the promise was fulfilled with.

--- a/Sources/FBLPromises/include/FBLPromise.h
+++ b/Sources/FBLPromises/include/FBLPromise.h
@@ -55,13 +55,20 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)reject:(NSError *)error NS_REFINED_FOR_SWIFT;
 
-/**
- Add an object to the set of pending objects to keep strongly while the promise is pending.
- */
-- (void)__addPendingObject:(id)object;
-
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
+@end
+
+@interface FBLPromise<Value>()
+
+/**
+ Adds an object to the set of pending objects to keep strongly while the promise is pending.
+ Used by the Swift wrappers to keep them alive until the underlying ObjC promise is resolved.
+
+ @param object An object to add.
+ */
+- (void)addPendingObject:(id)object NS_REFINED_FOR_SWIFT;
+
 @end
 
 #ifdef FBL_PROMISES_DOT_SYNTAX_IS_DEPRECATED

--- a/Sources/FBLPromises/include/FBLPromise.h
+++ b/Sources/FBLPromises/include/FBLPromise.h
@@ -55,14 +55,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)reject:(NSError *)error NS_REFINED_FOR_SWIFT;
 
-+ (instancetype)new NS_UNAVAILABLE;
-- (instancetype)init NS_UNAVAILABLE;
-
 /**
  Add an object to the set of pending objects to keep strongly while the promise is pending.
  */
-- (void)addToPendingObjects:(id)object NS_REFINED_FOR_SWIFT;
+- (void)__addPendingObject:(id)object;
 
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 @end
 
 #ifdef FBL_PROMISES_DOT_SYNTAX_IS_DEPRECATED

--- a/Sources/FBLPromises/include/FBLPromise.h
+++ b/Sources/FBLPromises/include/FBLPromise.h
@@ -58,6 +58,11 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 
+/**
+ Add an object to the set of pending objects to keep strongly while the promise is pending.
+ */
+- (void)addToPendingObjects:(id)object NS_REFINED_FOR_SWIFT;
+
 @end
 
 #ifdef FBL_PROMISES_DOT_SYNTAX_IS_DEPRECATED

--- a/Sources/Promises/Promise+All.swift
+++ b/Sources/Promises/Promise+All.swift
@@ -47,7 +47,7 @@ public func all<Value, Container: Sequence>(
   )
   // Keep Swift wrapper alive for chained promises until `ObjCPromise` counterpart is resolved.
   promises.forEach {
-    $0.__add(toPendingObjects: promise)
+    $0.__addPendingObject(promise)
   }
   return promise
 }
@@ -86,7 +86,7 @@ public func all<A, B>(
   )
   // Keep Swift wrapper alive for chained promises until `ObjCPromise` counterpart is resolved.
   promises.forEach {
-    $0.__add(toPendingObjects: promise)
+    $0.__addPendingObject(promise)
   }
   return promise
 }
@@ -129,7 +129,7 @@ public func all<A, B, C>(
   )
   // Keep Swift wrapper alive for chained promises until `ObjCPromise` counterpart is resolved.
   promises.forEach {
-    $0.__add(toPendingObjects: promise)
+    $0.__addPendingObject(promise)
   }
   return promise
 }
@@ -176,7 +176,7 @@ public func all<A, B, C, D>(
   )
   // Keep Swift wrapper alive for chained promises until `ObjCPromise` counterpart is resolved.
   promises.forEach {
-    $0.__add(toPendingObjects: promise)
+    $0.__addPendingObject(promise)
   }
   return promise
 }

--- a/Sources/Promises/Promise+All.swift
+++ b/Sources/Promises/Promise+All.swift
@@ -47,7 +47,7 @@ public func all<Value, Container: Sequence>(
   )
   // Keep Swift wrapper alive for chained promises until `ObjCPromise` counterpart is resolved.
   promises.forEach {
-    $0.__pendingObjects?.add(promise)
+    $0.__add(toPendingObjects: promise)
   }
   return promise
 }
@@ -86,7 +86,7 @@ public func all<A, B>(
   )
   // Keep Swift wrapper alive for chained promises until `ObjCPromise` counterpart is resolved.
   promises.forEach {
-    $0.__pendingObjects?.add(promise)
+    $0.__add(toPendingObjects: promise)
   }
   return promise
 }
@@ -129,7 +129,7 @@ public func all<A, B, C>(
   )
   // Keep Swift wrapper alive for chained promises until `ObjCPromise` counterpart is resolved.
   promises.forEach {
-    $0.__pendingObjects?.add(promise)
+    $0.__add(toPendingObjects: promise)
   }
   return promise
 }
@@ -176,7 +176,7 @@ public func all<A, B, C, D>(
   )
   // Keep Swift wrapper alive for chained promises until `ObjCPromise` counterpart is resolved.
   promises.forEach {
-    $0.__pendingObjects?.add(promise)
+    $0.__add(toPendingObjects: promise)
   }
   return promise
 }

--- a/Sources/Promises/Promise+Always.swift
+++ b/Sources/Promises/Promise+Always.swift
@@ -25,7 +25,7 @@ public extension Promise {
   func always(on queue: DispatchQueue = .promises, _ work: @escaping () -> Void) -> Promise {
     let promise = Promise(objCPromise.__onQueue(queue, always: work))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__add(toPendingObjects: promise)
+    objCPromise.__addPendingObject(promise)
     return promise
   }
 }

--- a/Sources/Promises/Promise+Always.swift
+++ b/Sources/Promises/Promise+Always.swift
@@ -25,7 +25,7 @@ public extension Promise {
   func always(on queue: DispatchQueue = .promises, _ work: @escaping () -> Void) -> Promise {
     let promise = Promise(objCPromise.__onQueue(queue, always: work))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__pendingObjects?.add(promise)
+    objCPromise.__add(toPendingObjects: promise)
     return promise
   }
 }

--- a/Sources/Promises/Promise+Any.swift
+++ b/Sources/Promises/Promise+Any.swift
@@ -59,7 +59,7 @@ public func any<Value, Container: Sequence>(
   )
   // Keep Swift wrapper alive for chained promises until `ObjCPromise` counterpart is resolved.
   promises.forEach {
-    $0.__add(toPendingObjects: promise)
+    $0.__addPendingObject(promise)
   }
   return promise
 }
@@ -98,7 +98,7 @@ public func any<A, B>(
   )
   // Keep Swift wrapper alive for chained promises until `ObjCPromise` counterpart is resolved.
   promises.forEach {
-    $0.__add(toPendingObjects: promise)
+    $0.__addPendingObject(promise)
   }
   return promise
 }
@@ -141,7 +141,7 @@ public func any<A, B, C>(
   )
   // Keep Swift wrapper alive for chained promises until `ObjCPromise` counterpart is resolved.
   promises.forEach {
-    $0.__add(toPendingObjects: promise)
+    $0.__addPendingObject(promise)
   }
   return promise
 }

--- a/Sources/Promises/Promise+Any.swift
+++ b/Sources/Promises/Promise+Any.swift
@@ -59,7 +59,7 @@ public func any<Value, Container: Sequence>(
   )
   // Keep Swift wrapper alive for chained promises until `ObjCPromise` counterpart is resolved.
   promises.forEach {
-    $0.__pendingObjects?.add(promise)
+    $0.__add(toPendingObjects: promise)
   }
   return promise
 }
@@ -98,7 +98,7 @@ public func any<A, B>(
   )
   // Keep Swift wrapper alive for chained promises until `ObjCPromise` counterpart is resolved.
   promises.forEach {
-    $0.__pendingObjects?.add(promise)
+    $0.__add(toPendingObjects: promise)
   }
   return promise
 }
@@ -141,7 +141,7 @@ public func any<A, B, C>(
   )
   // Keep Swift wrapper alive for chained promises until `ObjCPromise` counterpart is resolved.
   promises.forEach {
-    $0.__pendingObjects?.add(promise)
+    $0.__add(toPendingObjects: promise)
   }
   return promise
 }

--- a/Sources/Promises/Promise+Async.swift
+++ b/Sources/Promises/Promise+Async.swift
@@ -37,6 +37,6 @@ public extension Promise {
     }
     self.init(objCPromise)
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__add(toPendingObjects: self)
+    objCPromise.__addPendingObject(self)
   }
 }

--- a/Sources/Promises/Promise+Async.swift
+++ b/Sources/Promises/Promise+Async.swift
@@ -37,6 +37,6 @@ public extension Promise {
     }
     self.init(objCPromise)
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__pendingObjects?.add(self)
+    objCPromise.__add(toPendingObjects: self)
   }
 }

--- a/Sources/Promises/Promise+Catch.swift
+++ b/Sources/Promises/Promise+Catch.swift
@@ -31,7 +31,7 @@ public extension Promise {
       return reject(error as NSError)
     }))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__pendingObjects?.add(promise)
+    objCPromise.__add(toPendingObjects: promise)
     return promise
   }
 }

--- a/Sources/Promises/Promise+Catch.swift
+++ b/Sources/Promises/Promise+Catch.swift
@@ -31,7 +31,7 @@ public extension Promise {
       return reject(error as NSError)
     }))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__add(toPendingObjects: promise)
+    objCPromise.__addPendingObject(promise)
     return promise
   }
 }

--- a/Sources/Promises/Promise+Delay.swift
+++ b/Sources/Promises/Promise+Delay.swift
@@ -29,7 +29,7 @@ public extension Promise {
   ) -> Promise<Value> {
     let promise = Promise(objCPromise.__onQueue(queue, delay: interval))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__add(toPendingObjects: promise)
+    objCPromise.__addPendingObject(promise)
     return promise
   }
 }

--- a/Sources/Promises/Promise+Delay.swift
+++ b/Sources/Promises/Promise+Delay.swift
@@ -29,7 +29,7 @@ public extension Promise {
   ) -> Promise<Value> {
     let promise = Promise(objCPromise.__onQueue(queue, delay: interval))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__pendingObjects?.add(promise)
+    objCPromise.__add(toPendingObjects: promise)
     return promise
   }
 }

--- a/Sources/Promises/Promise+Do.swift
+++ b/Sources/Promises/Promise+Do.swift
@@ -34,7 +34,7 @@ public extension Promise {
     }
     self.init(objCPromise)
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__pendingObjects?.add(self)
+    objCPromise.__add(toPendingObjects: self)
   }
 
   /// Creates a pending promise to be resolved with the same resolution as the promise returned from
@@ -55,6 +55,6 @@ public extension Promise {
     }
     self.init(objCPromise)
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__pendingObjects?.add(self)
+    objCPromise.__add(toPendingObjects: self)
   }
 }

--- a/Sources/Promises/Promise+Do.swift
+++ b/Sources/Promises/Promise+Do.swift
@@ -34,7 +34,7 @@ public extension Promise {
     }
     self.init(objCPromise)
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__add(toPendingObjects: self)
+    objCPromise.__addPendingObject(self)
   }
 
   /// Creates a pending promise to be resolved with the same resolution as the promise returned from
@@ -55,6 +55,6 @@ public extension Promise {
     }
     self.init(objCPromise)
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__add(toPendingObjects: self)
+    objCPromise.__addPendingObject(self)
   }
 }

--- a/Sources/Promises/Promise+Race.swift
+++ b/Sources/Promises/Promise+Race.swift
@@ -47,7 +47,7 @@ public func race<Value>(
   )
   // Keep Swift wrapper alive for chained promises until `ObjCPromise` counterpart is resolved.
   promises.forEach {
-    $0.__add(toPendingObjects: promise)
+    $0.__addPendingObject(promise)
   }
   return promise
 }

--- a/Sources/Promises/Promise+Race.swift
+++ b/Sources/Promises/Promise+Race.swift
@@ -47,7 +47,7 @@ public func race<Value>(
   )
   // Keep Swift wrapper alive for chained promises until `ObjCPromise` counterpart is resolved.
   promises.forEach {
-    $0.__pendingObjects?.add(promise)
+    $0.__add(toPendingObjects: promise)
   }
   return promise
 }

--- a/Sources/Promises/Promise+Recover.swift
+++ b/Sources/Promises/Promise+Recover.swift
@@ -37,7 +37,7 @@ public extension Promise {
       }
     }))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__pendingObjects?.add(promise)
+    objCPromise.__add(toPendingObjects: promise)
     return promise
   }
 
@@ -62,7 +62,7 @@ public extension Promise {
       }
     }))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__pendingObjects?.add(promise)
+    objCPromise.__add(toPendingObjects: promise)
     return promise
   }
 }

--- a/Sources/Promises/Promise+Recover.swift
+++ b/Sources/Promises/Promise+Recover.swift
@@ -37,7 +37,7 @@ public extension Promise {
       }
     }))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__add(toPendingObjects: promise)
+    objCPromise.__addPendingObject(promise)
     return promise
   }
 
@@ -62,7 +62,7 @@ public extension Promise {
       }
     }))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__add(toPendingObjects: promise)
+    objCPromise.__addPendingObject(promise)
     return promise
   }
 }

--- a/Sources/Promises/Promise+Retry.swift
+++ b/Sources/Promises/Promise+Retry.swift
@@ -68,6 +68,6 @@ public func retry<Value>(
   }
   let promise = Promise<Value>(objCPromise)
   // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-  objCPromise.__pendingObjects?.add(promise)
+  objCPromise.__add(toPendingObjects: promise)
   return promise
 }

--- a/Sources/Promises/Promise+Retry.swift
+++ b/Sources/Promises/Promise+Retry.swift
@@ -68,6 +68,6 @@ public func retry<Value>(
   }
   let promise = Promise<Value>(objCPromise)
   // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-  objCPromise.__add(toPendingObjects: promise)
+  objCPromise.__addPendingObject(promise)
   return promise
 }

--- a/Sources/Promises/Promise+Then.swift
+++ b/Sources/Promises/Promise+Then.swift
@@ -42,7 +42,7 @@ public extension Promise {
       }
     }))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__pendingObjects?.add(promise)
+    objCPromise.__add(toPendingObjects: promise)
     return promise
   }
 
@@ -98,7 +98,7 @@ public extension Promise {
       }
     }))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__pendingObjects?.add(promise)
+    objCPromise.__add(toPendingObjects: promise)
     return promise
   }
 }

--- a/Sources/Promises/Promise+Then.swift
+++ b/Sources/Promises/Promise+Then.swift
@@ -42,7 +42,7 @@ public extension Promise {
       }
     }))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__add(toPendingObjects: promise)
+    objCPromise.__addPendingObject(promise)
     return promise
   }
 
@@ -70,7 +70,7 @@ public extension Promise {
       }
     }))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__pendingObjects?.add(promise)
+    objCPromise.__addPendingObject(promise)
     return promise
   }
 
@@ -98,7 +98,7 @@ public extension Promise {
       }
     }))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__add(toPendingObjects: promise)
+    objCPromise.__addPendingObject(promise)
     return promise
   }
 }

--- a/Sources/Promises/Promise+Timeout.swift
+++ b/Sources/Promises/Promise+Timeout.swift
@@ -26,7 +26,7 @@ public extension Promise {
   func timeout(on queue: DispatchQueue = .promises, _ interval: TimeInterval) -> Promise {
     let promise = Promise(objCPromise.__onQueue(queue, timeout: interval))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__pendingObjects?.add(promise)
+    objCPromise.__add(toPendingObjects: promise)
     return promise
   }
 }

--- a/Sources/Promises/Promise+Timeout.swift
+++ b/Sources/Promises/Promise+Timeout.swift
@@ -26,7 +26,7 @@ public extension Promise {
   func timeout(on queue: DispatchQueue = .promises, _ interval: TimeInterval) -> Promise {
     let promise = Promise(objCPromise.__onQueue(queue, timeout: interval))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__add(toPendingObjects: promise)
+    objCPromise.__addPendingObject(promise)
     return promise
   }
 }

--- a/Sources/Promises/Promise+Validate.swift
+++ b/Sources/Promises/Promise+Validate.swift
@@ -41,7 +41,7 @@ public extension Promise {
       }
     ))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__pendingObjects?.add(promise)
+    objCPromise.__add(toPendingObjects: promise)
     return promise
   }
 }

--- a/Sources/Promises/Promise+Validate.swift
+++ b/Sources/Promises/Promise+Validate.swift
@@ -41,7 +41,7 @@ public extension Promise {
       }
     ))
     // Keep Swift wrapper alive for chained promise until `ObjCPromise` counterpart is resolved.
-    objCPromise.__add(toPendingObjects: promise)
+    objCPromise.__addPendingObject(promise)
     return promise
   }
 }

--- a/Tests/FBLPromisesTests/FBLPromiseTests.m
+++ b/Tests/FBLPromisesTests/FBLPromiseTests.m
@@ -34,7 +34,7 @@
   XCTAssertTrue(promise.isPending);
   XCTAssertFalse(promise.isFulfilled);
   XCTAssertFalse(promise.isRejected);
-  XCTAssertNotNil(promise.pendingObjects);
+  XCTAssertFalse(promise.isPendingObjectsEmpty);
   XCTAssertNil(promise.value);
   XCTAssertNil(promise.error);
 }
@@ -50,7 +50,7 @@
   XCTAssertFalse(promise.isPending);
   XCTAssertTrue(promise.isFulfilled);
   XCTAssertFalse(promise.isRejected);
-  XCTAssertNil(promise.pendingObjects);
+  XCTAssertTrue(promise.isPendingObjectsEmpty);
   XCTAssertEqualObjects(promise.value, @42);
   XCTAssertNil(promise.error);
 }
@@ -67,7 +67,7 @@
   XCTAssertFalse(promise.isPending);
   XCTAssertFalse(promise.isFulfilled);
   XCTAssertTrue(promise.isRejected);
-  XCTAssertNil(promise.pendingObjects);
+  XCTAssertTrue(promise.isPendingObjectsEmpty);
   XCTAssertNil(promise.value);
   XCTAssertEqualObjects(promise.error.domain, FBLPromiseErrorDomain);
   XCTAssertEqual(promise.error.code, 42);
@@ -87,7 +87,7 @@
   XCTAssertFalse(promise.isPending);
   XCTAssertTrue(promise.isFulfilled);
   XCTAssertFalse(promise.isRejected);
-  XCTAssertNil(promise.pendingObjects);
+  XCTAssertTrue(promise.isPendingObjectsEmpty);
   XCTAssertEqualObjects(promise.value, @42);
   XCTAssertNil(promise.error);
 }
@@ -107,7 +107,7 @@
   XCTAssertFalse(promise.isPending);
   XCTAssertTrue(promise.isFulfilled);
   XCTAssertFalse(promise.isRejected);
-  XCTAssertNil(promise.pendingObjects);
+  XCTAssertTrue(promise.isPendingObjectsEmpty);
   XCTAssertEqualObjects(promise.value, @42);
   XCTAssertNil(promise.error);
 }
@@ -126,7 +126,7 @@
   XCTAssertFalse(promise.isPending);
   XCTAssertFalse(promise.isFulfilled);
   XCTAssertTrue(promise.isRejected);
-  XCTAssertNil(promise.pendingObjects);
+  XCTAssertTrue(promise.isPendingObjectsEmpty);
   XCTAssertNil(promise.value);
   XCTAssertEqualObjects(promise.error.domain, FBLPromiseErrorDomain);
   XCTAssertEqual(promise.error.code, 42);
@@ -146,7 +146,7 @@
   XCTAssertFalse(promise.isPending);
   XCTAssertFalse(promise.isFulfilled);
   XCTAssertTrue(promise.isRejected);
-  XCTAssertNil(promise.pendingObjects);
+  XCTAssertTrue(promise.isPendingObjectsEmpty);
   XCTAssertNil(promise.value);
   XCTAssertEqualObjects(promise.error.domain, FBLPromiseErrorDomain);
   XCTAssertEqual(promise.error.code, 42);
@@ -167,7 +167,7 @@
   XCTAssertFalse(promise.isPending);
   XCTAssertFalse(promise.isFulfilled);
   XCTAssertTrue(promise.isRejected);
-  XCTAssertNil(promise.pendingObjects);
+  XCTAssertTrue(promise.isPendingObjectsEmpty);
   XCTAssertNil(promise.value);
   XCTAssertEqualObjects(promise.error.domain, FBLPromiseErrorDomain);
   XCTAssertEqual(promise.error.code, 42);
@@ -188,7 +188,7 @@
   XCTAssertFalse(promise.isPending);
   XCTAssertTrue(promise.isFulfilled);
   XCTAssertFalse(promise.isRejected);
-  XCTAssertNil(promise.pendingObjects);
+  XCTAssertTrue(promise.isPendingObjectsEmpty);
   XCTAssertEqualObjects(promise.value, @42);
   XCTAssertNil(promise.error);
 }
@@ -208,7 +208,7 @@
   XCTAssertFalse(promise.isPending);
   XCTAssertFalse(promise.isFulfilled);
   XCTAssertTrue(promise.isRejected);
-  XCTAssertNil(promise.pendingObjects);
+  XCTAssertTrue(promise.isPendingObjectsEmpty);
   XCTAssertNil(promise.value);
   XCTAssertEqualObjects(promise.error.domain, FBLPromiseErrorDomain);
   XCTAssertEqual(promise.error.code, 42);

--- a/Tests/FBLPromisesTests/FBLPromiseTests.m
+++ b/Tests/FBLPromisesTests/FBLPromiseTests.m
@@ -34,7 +34,6 @@
   XCTAssertTrue(promise.isPending);
   XCTAssertFalse(promise.isFulfilled);
   XCTAssertFalse(promise.isRejected);
-  XCTAssertFalse(promise.isPendingObjectsEmpty);
   XCTAssertNil(promise.value);
   XCTAssertNil(promise.error);
 }
@@ -50,7 +49,6 @@
   XCTAssertFalse(promise.isPending);
   XCTAssertTrue(promise.isFulfilled);
   XCTAssertFalse(promise.isRejected);
-  XCTAssertTrue(promise.isPendingObjectsEmpty);
   XCTAssertEqualObjects(promise.value, @42);
   XCTAssertNil(promise.error);
 }
@@ -67,7 +65,6 @@
   XCTAssertFalse(promise.isPending);
   XCTAssertFalse(promise.isFulfilled);
   XCTAssertTrue(promise.isRejected);
-  XCTAssertTrue(promise.isPendingObjectsEmpty);
   XCTAssertNil(promise.value);
   XCTAssertEqualObjects(promise.error.domain, FBLPromiseErrorDomain);
   XCTAssertEqual(promise.error.code, 42);
@@ -87,7 +84,6 @@
   XCTAssertFalse(promise.isPending);
   XCTAssertTrue(promise.isFulfilled);
   XCTAssertFalse(promise.isRejected);
-  XCTAssertTrue(promise.isPendingObjectsEmpty);
   XCTAssertEqualObjects(promise.value, @42);
   XCTAssertNil(promise.error);
 }
@@ -107,7 +103,6 @@
   XCTAssertFalse(promise.isPending);
   XCTAssertTrue(promise.isFulfilled);
   XCTAssertFalse(promise.isRejected);
-  XCTAssertTrue(promise.isPendingObjectsEmpty);
   XCTAssertEqualObjects(promise.value, @42);
   XCTAssertNil(promise.error);
 }
@@ -126,7 +121,6 @@
   XCTAssertFalse(promise.isPending);
   XCTAssertFalse(promise.isFulfilled);
   XCTAssertTrue(promise.isRejected);
-  XCTAssertTrue(promise.isPendingObjectsEmpty);
   XCTAssertNil(promise.value);
   XCTAssertEqualObjects(promise.error.domain, FBLPromiseErrorDomain);
   XCTAssertEqual(promise.error.code, 42);
@@ -146,7 +140,6 @@
   XCTAssertFalse(promise.isPending);
   XCTAssertFalse(promise.isFulfilled);
   XCTAssertTrue(promise.isRejected);
-  XCTAssertTrue(promise.isPendingObjectsEmpty);
   XCTAssertNil(promise.value);
   XCTAssertEqualObjects(promise.error.domain, FBLPromiseErrorDomain);
   XCTAssertEqual(promise.error.code, 42);
@@ -167,7 +160,6 @@
   XCTAssertFalse(promise.isPending);
   XCTAssertFalse(promise.isFulfilled);
   XCTAssertTrue(promise.isRejected);
-  XCTAssertTrue(promise.isPendingObjectsEmpty);
   XCTAssertNil(promise.value);
   XCTAssertEqualObjects(promise.error.domain, FBLPromiseErrorDomain);
   XCTAssertEqual(promise.error.code, 42);
@@ -188,7 +180,6 @@
   XCTAssertFalse(promise.isPending);
   XCTAssertTrue(promise.isFulfilled);
   XCTAssertFalse(promise.isRejected);
-  XCTAssertTrue(promise.isPendingObjectsEmpty);
   XCTAssertEqualObjects(promise.value, @42);
   XCTAssertNil(promise.error);
 }
@@ -208,7 +199,6 @@
   XCTAssertFalse(promise.isPending);
   XCTAssertFalse(promise.isFulfilled);
   XCTAssertTrue(promise.isRejected);
-  XCTAssertTrue(promise.isPendingObjectsEmpty);
   XCTAssertNil(promise.value);
   XCTAssertEqualObjects(promise.error.domain, FBLPromiseErrorDomain);
   XCTAssertEqual(promise.error.code, 42);


### PR DESCRIPTION
Swift uses the NSMutableSet to hold on to references of Swift promises but the
modifications must be synchronized.

This is intended to fix #141.