### PR TITLE
[Gardening] - Fix incorrect type annotation in Objective-C tests.

### DIFF
--- a/Tests/FBLPromisesTests/FBLPromise+ThenTests.m
+++ b/Tests/FBLPromisesTests/FBLPromise+ThenTests.m
@@ -46,7 +46,7 @@
     }];
   }];
   typedef NSArray<NSNumber *> * (^BlockPromise)(NSNumber *);
-  FBLPromise<BlockPromise> *blockPromise = [stringPromise then:^id(NSNumber *value) {
+  FBLPromise<BlockPromise> *blockPromise = [stringPromise then:^id(NSString *value) {
     ++count;
     return [FBLPromise async:^(FBLPromiseFulfillBlock fulfill, FBLPromiseRejectBlock __unused _) {
       fulfill(^(NSNumber *number) {
@@ -220,7 +220,7 @@
     return value.stringValue;
   }];
   typedef NSArray<NSNumber *> * (^BlockPromise)(NSNumber *);
-  FBLPromise<BlockPromise> *blockPromise = [stringPromise then:^id(NSNumber *value) {
+  FBLPromise<BlockPromise> *blockPromise = [stringPromise then:^id(NSString *value) {
     ++count;
     return ^(NSNumber *number) {
       return @[ @(number.integerValue + value.integerValue) ];


### PR DESCRIPTION
* Found when running the tests on Xcode 11.4.1

![Screenshot 2020-05-18 at 11 45 34](https://user-images.githubusercontent.com/993745/82204599-18e48a00-98fd-11ea-8105-926da215614a.png)
