### PR TITLE
Specify every platform but watchOS in test spec

### DIFF
--- a/PromisesObjC.podspec
+++ b/PromisesObjC.podspec
@@ -28,10 +28,12 @@ Pod::Spec.new do |s|
   }
 
   s.test_spec 'Tests' do |ts|
+    ts.platforms = {:ios => '8.0', :osx => '10.10', :tvos => '9.0'}
     ts.source_files = "Tests/#{s.module_name}Tests/*.m",
                       "Sources/#{s.module_name}TestHelpers/include/#{s.module_name}TestHelpers.h"
   end
   s.test_spec 'PerformanceTests' do |ts|
+    ts.platforms = {:ios => '8.0', :osx => '10.10', :tvos => '9.0'}
     ts.source_files = "Tests/#{s.module_name}PerformanceTests/*.m",
                       "Sources/#{s.module_name}TestHelpers/include/#{s.module_name}TestHelpers.h"
   end

--- a/PromisesObjC.podspec
+++ b/PromisesObjC.podspec
@@ -28,11 +28,15 @@ Pod::Spec.new do |s|
   }
 
   s.test_spec 'Tests' do |ts|
+    # Note: Omits watchOS as a workaround since XCTest is not available to watchOS for now.
+    # Reference: https://github.com/CocoaPods/CocoaPods/issues/8283.
     ts.platforms = {:ios => '8.0', :osx => '10.10', :tvos => '9.0'}
     ts.source_files = "Tests/#{s.module_name}Tests/*.m",
                       "Sources/#{s.module_name}TestHelpers/include/#{s.module_name}TestHelpers.h"
   end
   s.test_spec 'PerformanceTests' do |ts|
+    # Note: Omits watchOS as a workaround since XCTest is not available to watchOS for now.
+    # Reference: https://github.com/CocoaPods/CocoaPods/issues/8283.
     ts.platforms = {:ios => '8.0', :osx => '10.10', :tvos => '9.0'}
     ts.source_files = "Tests/#{s.module_name}PerformanceTests/*.m",
                       "Sources/#{s.module_name}TestHelpers/include/#{s.module_name}TestHelpers.h"

--- a/PromisesObjC.podspec
+++ b/PromisesObjC.podspec
@@ -29,15 +29,15 @@ Pod::Spec.new do |s|
 
   s.test_spec 'Tests' do |ts|
     # Note: Omits watchOS as a workaround since XCTest is not available to watchOS for now.
-    # Reference: https://github.com/CocoaPods/CocoaPods/issues/8283.
-    ts.platforms = {:ios => '8.0', :osx => '10.10', :tvos => '9.0'}
+    # Reference: https://github.com/CocoaPods/CocoaPods/issues/8283, https://github.com/CocoaPods/CocoaPods/issues/4185.
+    ts.platforms = {:ios => nil, :osx => nil, :tvos => nil}
     ts.source_files = "Tests/#{s.module_name}Tests/*.m",
                       "Sources/#{s.module_name}TestHelpers/include/#{s.module_name}TestHelpers.h"
   end
   s.test_spec 'PerformanceTests' do |ts|
     # Note: Omits watchOS as a workaround since XCTest is not available to watchOS for now.
-    # Reference: https://github.com/CocoaPods/CocoaPods/issues/8283.
-    ts.platforms = {:ios => '8.0', :osx => '10.10', :tvos => '9.0'}
+    # Reference: https://github.com/CocoaPods/CocoaPods/issues/8283, https://github.com/CocoaPods/CocoaPods/issues/4185.
+    ts.platforms = {:ios => nil, :osx => nil, :tvos => nil}
     ts.source_files = "Tests/#{s.module_name}PerformanceTests/*.m",
                       "Sources/#{s.module_name}TestHelpers/include/#{s.module_name}TestHelpers.h"
   end


### PR DESCRIPTION
This pull request fixes this issue: #147 .

According to https://github.com/CocoaPods/CocoaPods/issues/8283, `cocoapods test spec` does not seem to support watchOS for now.
So `PromisesObjC.podspec` needs a workaround in the meantime.

NOTE:
#145 also shoud be merged to fix `pod lib lint error` about PromisesObjC.podspec.

Thanks.