### PR TITLE
Added swift_version to PromisesSwift.podspec. Fix of #150.

### DIFF
--- a/PromisesSwift.podspec
+++ b/PromisesSwift.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target  = '10.10'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
+  s.swift_versions = ['5.0', '5.2']
 
   s.module_name = 'Promises'
   s.source_files = "Sources/#{s.module_name}/*.{swift}"


### PR DESCRIPTION
Fixing issue #150 where cocoapods require `swift_version` to be specified if Podfile declares `:inherit_targets => false`.

The issue #150 is the result of the[ issue with target settings validation](https://github.com/CocoaPods/CocoaPods/pull/8672) in CocoaPods that is decided not to be fixed.