### PR TITLE
Resolve Xcode 12 minimum iOS version warnings

### DIFF
--- a/PromisesObjC.podspec
+++ b/PromisesObjC.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   Objective-C to facilitate writing asynchronous code.
                      DESC
 
-  s.ios.deployment_target  = '8.0'
+  s.ios.deployment_target  = '9.0'
   s.osx.deployment_target  = '10.10'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'

--- a/PromisesSwift.podspec
+++ b/PromisesSwift.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   Swift to facilitate writing asynchronous code.
                      DESC
 
-  s.ios.deployment_target  = '8.0'
+  s.ios.deployment_target  = '9.0'
   s.osx.deployment_target  = '10.10'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'


### PR DESCRIPTION
Xcode 12 generates build warnings for iOS versions less than 9. More context at CocoaPods/CocoaPods#9884.

I confirmed that the macos and tvos versions are still ok in Xcode 12.