### PR TITLE
Fix compilation error with -std=c11 by not using vendor extensions

### DIFF
--- a/Sources/FBLPromises/FBLPromise+Timeout.m
+++ b/Sources/FBLPromises/FBLPromise+Timeout.m
@@ -35,7 +35,7 @@
       reject:^(NSError *error) {
         [promise reject:error];
       }];
-  typeof(self) __weak weakPromise = promise;
+  FBLPromise* __weak weakPromise = promise;
   dispatch_after(dispatch_time(0, (int64_t)(interval * NSEC_PER_SEC)), queue, ^{
     NSError *timedOutError = [[NSError alloc] initWithDomain:FBLPromiseErrorDomain
                                                         code:FBLPromiseErrorCodeTimedOut


### PR DESCRIPTION
Example:
../../third_party/promises/src/Sources/FBLPromises/FBLPromise+Timeout.m:38:3: error: implicit declaration of function 'typeof' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  typeof(self) __weak weakPromise = promise;