### PR TITLE
fix PromisesSwift cannot be integrated as static libraries

### DIFF
--- a/PromisesObjC.podspec
+++ b/PromisesObjC.podspec
@@ -23,7 +23,8 @@ Pod::Spec.new do |s|
   s.public_header_files = "Sources/#{s.module_name}/include/**/*.h"
   s.private_header_files = "Sources/#{s.module_name}/include/FBLPromisePrivate.h"
   s.source_files = "Sources/#{s.module_name}/**/*.{h,m}"
-  s.xcconfig = {
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
     'HEADER_SEARCH_PATHS' => "\"${PODS_TARGET_SRCROOT}/Sources/#{s.module_name}/include\""
   }
 


### PR DESCRIPTION

```ruby
[!] The following Swift pods cannot yet be integrated as static libraries:

The Swift pod `PromisesSwift` depends upon `PromisesObjC`, which does not define modules. To opt into those targets generating module maps (which is necessary to import them from Swift when building as static libraries), you may set `use_modular_headers!` globally in your Podfile, or specify `:modular_headers => true` for particular dependencies.
```

now `PromisesSwift` can be integrated as `static libraries` with `CocoaPods`.