### PR TITLE
Move dispatch_after and dispatch_group_async to class methods

### DIFF
--- a/Sources/FBLPromises/FBLPromise+All.m
+++ b/Sources/FBLPromises/FBLPromise+All.m
@@ -30,22 +30,22 @@
   NSParameterAssert(allPromises);
 
   if (allPromises.count == 0) {
-    return [[FBLPromise alloc] initWithResolution:@[]];
+    return [[self alloc] initWithResolution:@[]];
   }
   NSMutableArray *promises = [allPromises mutableCopy];
-  return [FBLPromise
+  return [self
       onQueue:queue
         async:^(FBLPromiseFulfillBlock fulfill, FBLPromiseRejectBlock reject) {
           for (NSUInteger i = 0; i < promises.count; ++i) {
             id promise = promises[i];
-            if ([promise isKindOfClass:self]) {
+            if ([promise isKindOfClass:[FBLPromise class]]) {
               continue;
             } else if ([promise isKindOfClass:[NSError class]]) {
               reject(promise);
               return;
             } else {
               [promises replaceObjectAtIndex:i
-                                  withObject:[[FBLPromise alloc] initWithResolution:promise]];
+                                  withObject:[[self alloc] initWithResolution:promise]];
             }
           }
           for (FBLPromise *promise in promises) {

--- a/Sources/FBLPromises/FBLPromise+Any.m
+++ b/Sources/FBLPromises/FBLPromise+Any.m
@@ -46,19 +46,19 @@ static NSArray *FBLPromiseCombineValuesAndErrors(NSArray<FBLPromise *> *promises
   NSParameterAssert(anyPromises);
 
   if (anyPromises.count == 0) {
-    return [[FBLPromise alloc] initWithResolution:@[]];
+    return [[self alloc] initWithResolution:@[]];
   }
   NSMutableArray *promises = [anyPromises mutableCopy];
-  return [FBLPromise
+  return [self
       onQueue:queue
         async:^(FBLPromiseFulfillBlock fulfill, FBLPromiseRejectBlock reject) {
           for (NSUInteger i = 0; i < promises.count; ++i) {
             id promise = promises[i];
-            if ([promise isKindOfClass:self]) {
+            if ([promise isKindOfClass:[FBLPromise class]]) {
               continue;
             } else {
               [promises replaceObjectAtIndex:i
-                                  withObject:[[FBLPromise alloc] initWithResolution:promise]];
+                                  withObject:[[self alloc] initWithResolution:promise]];
             }
           }
           for (FBLPromise *promise in promises) {

--- a/Sources/FBLPromises/FBLPromise+Async.m
+++ b/Sources/FBLPromises/FBLPromise+Async.m
@@ -28,8 +28,8 @@
   NSParameterAssert(queue);
   NSParameterAssert(work);
 
-  FBLPromise *promise = [[FBLPromise alloc] initPending];
-  dispatch_group_async(FBLPromise.dispatchGroup, queue, ^{
+  FBLPromise *promise = [[self alloc] initPending];
+  [self dispatchOnQueue:queue block:^{
     work(
         ^(id __nullable value) {
           if ([value isKindOfClass:[FBLPromise class]]) {
@@ -47,7 +47,7 @@
         ^(NSError *error) {
           [promise reject:error];
         });
-  });
+  }];
   return promise;
 }
 

--- a/Sources/FBLPromises/FBLPromise+Delay.m
+++ b/Sources/FBLPromises/FBLPromise+Delay.m
@@ -27,12 +27,15 @@
 - (FBLPromise *)onQueue:(dispatch_queue_t)queue delay:(NSTimeInterval)interval {
   NSParameterAssert(queue);
 
-  FBLPromise *promise = [[FBLPromise alloc] initPending];
+  FBLPromise *promise = [[[self class] alloc] initPending];
+  Class class = [self class];
   [self observeOnQueue:queue
       fulfill:^(id __nullable value) {
-        dispatch_after(dispatch_time(0, (int64_t)(interval * NSEC_PER_SEC)), queue, ^{
+        [class dispatchAfter:dispatch_time(0, (int64_t)(interval * NSEC_PER_SEC))
+                       queue:queue
+                       block:^{
           [promise fulfill:value];
-        });
+        }];
       }
       reject:^(NSError *error) {
         [promise reject:error];

--- a/Sources/FBLPromises/FBLPromise+Do.m
+++ b/Sources/FBLPromises/FBLPromise+Do.m
@@ -28,8 +28,8 @@
   NSParameterAssert(queue);
   NSParameterAssert(work);
 
-  FBLPromise *promise = [[FBLPromise alloc] initPending];
-  dispatch_group_async(FBLPromise.dispatchGroup, queue, ^{
+  FBLPromise *promise = [[[self class] alloc] initPending];
+  [self dispatchOnQueue:queue block:^{
     id value = work();
     if ([value isKindOfClass:[FBLPromise class]]) {
       [(FBLPromise *)value observeOnQueue:queue
@@ -42,7 +42,7 @@
     } else {
       [promise fulfill:value];
     }
-  });
+  }];
   return promise;
 }
 

--- a/Sources/FBLPromises/FBLPromise+Race.m
+++ b/Sources/FBLPromises/FBLPromise+Race.m
@@ -30,10 +30,10 @@
   NSAssert(racePromises.count > 0, @"No promises to observe");
 
   NSArray *promises = [racePromises copy];
-  return [FBLPromise onQueue:queue
+  return [self onQueue:queue
                        async:^(FBLPromiseFulfillBlock fulfill, FBLPromiseRejectBlock reject) {
                          for (id promise in promises) {
-                           if (![promise isKindOfClass:self]) {
+                           if (![promise isKindOfClass:[FBLPromise class]]) {
                              fulfill(promise);
                              return;
                            }

--- a/Sources/FBLPromises/FBLPromise+Retry.m
+++ b/Sources/FBLPromises/FBLPromise+Retry.m
@@ -29,9 +29,11 @@ static void FBLPromiseRetryAttempt(FBLPromise *promise, dispatch_queue_t queue, 
       if (count <= 0 || (predicate && !predicate(count, value))) {
         [promise reject:value];
       } else {
-        dispatch_after(dispatch_time(0, (int64_t)(interval * NSEC_PER_SEC)), queue, ^{
+        [[promise class] dispatchAfter:dispatch_time(0, (int64_t)(interval * NSEC_PER_SEC))
+                                 queue:queue
+                                 block:^{
           FBLPromiseRetryAttempt(promise, queue, count - 1, interval, predicate, work);
-        });
+        }];
       }
     } else {
       [promise fulfill:value];
@@ -88,7 +90,7 @@ static void FBLPromiseRetryAttempt(FBLPromise *promise, dispatch_queue_t queue, 
   NSParameterAssert(queue);
   NSParameterAssert(work);
 
-  FBLPromise *promise = [[FBLPromise alloc] initPending];
+  FBLPromise *promise = [[self alloc] initPending];
   FBLPromiseRetryAttempt(promise, queue, count, interval, predicate, work);
   return promise;
 }

--- a/Sources/FBLPromises/FBLPromise+Timeout.m
+++ b/Sources/FBLPromises/FBLPromise+Timeout.m
@@ -27,7 +27,7 @@
 - (FBLPromise *)onQueue:(dispatch_queue_t)queue timeout:(NSTimeInterval)interval {
   NSParameterAssert(queue);
 
-  FBLPromise *promise = [[FBLPromise alloc] initPending];
+  FBLPromise *promise = [[[self class] alloc] initPending];
   [self observeOnQueue:queue
       fulfill:^(id __nullable value) {
         [promise fulfill:value];
@@ -36,12 +36,14 @@
         [promise reject:error];
       }];
   FBLPromise* __weak weakPromise = promise;
-  dispatch_after(dispatch_time(0, (int64_t)(interval * NSEC_PER_SEC)), queue, ^{
+  [[self class] dispatchAfter:dispatch_time(0, (int64_t)(interval * NSEC_PER_SEC))
+                        queue:queue
+                        block:^{
     NSError *timedOutError = [[NSError alloc] initWithDomain:FBLPromiseErrorDomain
                                                         code:FBLPromiseErrorCodeTimedOut
                                                     userInfo:nil];
     [weakPromise reject:timedOutError];
-  });
+  }];
   return promise;
 }
 

--- a/Sources/FBLPromises/include/FBLPromisePrivate.h
+++ b/Sources/FBLPromises/include/FBLPromisePrivate.h
@@ -31,6 +31,19 @@ typedef id __nullable (^__nullable FBLPromiseChainedRejectBlock)(NSError *error)
     NS_SWIFT_UNAVAILABLE("");
 
 /**
+ Dispatches an asynchronous work block on the given queue. Same semantics as @c dispatch_async or
+ @c dispatch_group_async.
+ */
++ (void)dispatchOnQueue:(dispatch_queue_t)queue block:(dispatch_block_t)block;
+
+/**
+ Dispatches an asynchronous work block at a given time. Same semantics as @c dispatch_after.
+ */
++ (void)dispatchAfter:(dispatch_time_t)when
+                queue:(dispatch_queue_t)queue
+                block:(dispatch_block_t)block;
+
+/**
  Creates a pending promise.
  */
 - (instancetype)initPending NS_SWIFT_UNAVAILABLE("");


### PR DESCRIPTION
This PR moves dispatch_after and dispatch_group_async to class methods, so a subclass of FBLPromise could override the dispatch behavior (with access to FBLPromisePrivate.h).

Also updates a few other places to:
- Use [self alloc] or [[self class] alloc] instead of [FBLPromise alloc], to make sure methods are allocating the same class as the instance (or class)
- Use [FBLPromise class] in isKindOfClass: still, to not force exact subclass matching