### PR TITLE
Use `self`/`[self class]` in more places

### DIFF
--- a/Sources/FBLPromises/FBLPromise+All.m
+++ b/Sources/FBLPromises/FBLPromise+All.m
@@ -30,10 +30,10 @@
   NSParameterAssert(allPromises);
 
   if (allPromises.count == 0) {
-    return [[FBLPromise alloc] initWithResolution:@[]];
+    return [[self alloc] initWithResolution:@[]];
   }
   NSMutableArray *promises = [allPromises mutableCopy];
-  return [FBLPromise
+  return [self
       onQueue:queue
         async:^(FBLPromiseFulfillBlock fulfill, FBLPromiseRejectBlock reject) {
           for (NSUInteger i = 0; i < promises.count; ++i) {
@@ -45,7 +45,7 @@
               return;
             } else {
               [promises replaceObjectAtIndex:i
-                                  withObject:[[FBLPromise alloc] initWithResolution:promise]];
+                                  withObject:[[self alloc] initWithResolution:promise]];
             }
           }
           for (FBLPromise *promise in promises) {

--- a/Sources/FBLPromises/FBLPromise+Any.m
+++ b/Sources/FBLPromises/FBLPromise+Any.m
@@ -46,10 +46,10 @@ static NSArray *FBLPromiseCombineValuesAndErrors(NSArray<FBLPromise *> *promises
   NSParameterAssert(anyPromises);
 
   if (anyPromises.count == 0) {
-    return [[FBLPromise alloc] initWithResolution:@[]];
+    return [[self alloc] initWithResolution:@[]];
   }
   NSMutableArray *promises = [anyPromises mutableCopy];
-  return [FBLPromise
+  return [self
       onQueue:queue
         async:^(FBLPromiseFulfillBlock fulfill, FBLPromiseRejectBlock reject) {
           for (NSUInteger i = 0; i < promises.count; ++i) {
@@ -58,7 +58,7 @@ static NSArray *FBLPromiseCombineValuesAndErrors(NSArray<FBLPromise *> *promises
               continue;
             } else {
               [promises replaceObjectAtIndex:i
-                                  withObject:[[FBLPromise alloc] initWithResolution:promise]];
+                                  withObject:[[self alloc] initWithResolution:promise]];
             }
           }
           for (FBLPromise *promise in promises) {

--- a/Sources/FBLPromises/FBLPromise+Async.m
+++ b/Sources/FBLPromises/FBLPromise+Async.m
@@ -28,7 +28,7 @@
   NSParameterAssert(queue);
   NSParameterAssert(work);
 
-  FBLPromise *promise = [[FBLPromise alloc] initPending];
+  FBLPromise *promise = [[self alloc] initPending];
   dispatch_group_async(FBLPromise.dispatchGroup, queue, ^{
     work(
         ^(id __nullable value) {

--- a/Sources/FBLPromises/FBLPromise+Delay.m
+++ b/Sources/FBLPromises/FBLPromise+Delay.m
@@ -27,7 +27,7 @@
 - (FBLPromise *)onQueue:(dispatch_queue_t)queue delay:(NSTimeInterval)interval {
   NSParameterAssert(queue);
 
-  FBLPromise *promise = [[FBLPromise alloc] initPending];
+  FBLPromise *promise = [[[self class] alloc] initPending];
   [self observeOnQueue:queue
       fulfill:^(id __nullable value) {
         dispatch_after(dispatch_time(0, (int64_t)(interval * NSEC_PER_SEC)), queue, ^{

--- a/Sources/FBLPromises/FBLPromise+Do.m
+++ b/Sources/FBLPromises/FBLPromise+Do.m
@@ -28,7 +28,7 @@
   NSParameterAssert(queue);
   NSParameterAssert(work);
 
-  FBLPromise *promise = [[FBLPromise alloc] initPending];
+  FBLPromise *promise = [[self alloc] initPending];
   dispatch_group_async(FBLPromise.dispatchGroup, queue, ^{
     id value = work();
     if ([value isKindOfClass:[FBLPromise class]]) {

--- a/Sources/FBLPromises/FBLPromise+Race.m
+++ b/Sources/FBLPromises/FBLPromise+Race.m
@@ -30,7 +30,7 @@
   NSAssert(racePromises.count > 0, @"No promises to observe");
 
   NSArray *promises = [racePromises copy];
-  return [FBLPromise onQueue:queue
+  return [self onQueue:queue
                        async:^(FBLPromiseFulfillBlock fulfill, FBLPromiseRejectBlock reject) {
                          for (id promise in promises) {
                            if (![promise isKindOfClass:self]) {

--- a/Sources/FBLPromises/FBLPromise+Retry.m
+++ b/Sources/FBLPromises/FBLPromise+Retry.m
@@ -47,19 +47,19 @@ static void FBLPromiseRetryAttempt(FBLPromise *promise, dispatch_queue_t queue, 
 
 @implementation FBLPromise (RetryAdditions)
 
-+ (FBLPromise *)retry:(FBLPromiseRetryWorkBlock)work {
++ (instancetype)retry:(FBLPromiseRetryWorkBlock)work {
   return [self onQueue:FBLPromise.defaultDispatchQueue retry:work];
 }
 
-+ (FBLPromise *)onQueue:(dispatch_queue_t)queue retry:(FBLPromiseRetryWorkBlock)work {
++ (instancetype)onQueue:(dispatch_queue_t)queue retry:(FBLPromiseRetryWorkBlock)work {
   return [self onQueue:queue attempts:FBLPromiseRetryDefaultAttemptsCount retry:work];
 }
 
-+ (FBLPromise *)attempts:(NSInteger)count retry:(FBLPromiseRetryWorkBlock)work {
++ (instancetype)attempts:(NSInteger)count retry:(FBLPromiseRetryWorkBlock)work {
   return [self onQueue:FBLPromise.defaultDispatchQueue attempts:count retry:work];
 }
 
-+ (FBLPromise *)onQueue:(dispatch_queue_t)queue
++ (instancetype)onQueue:(dispatch_queue_t)queue
                attempts:(NSInteger)count
                   retry:(FBLPromiseRetryWorkBlock)work {
   return [self onQueue:queue
@@ -69,7 +69,7 @@ static void FBLPromiseRetryAttempt(FBLPromise *promise, dispatch_queue_t queue, 
                  retry:work];
 }
 
-+ (FBLPromise *)attempts:(NSInteger)count
++ (instancetype)attempts:(NSInteger)count
                    delay:(NSTimeInterval)interval
                condition:(nullable FBLPromiseRetryPredicateBlock)predicate
                    retry:(FBLPromiseRetryWorkBlock)work {
@@ -80,7 +80,7 @@ static void FBLPromiseRetryAttempt(FBLPromise *promise, dispatch_queue_t queue, 
                  retry:work];
 }
 
-+ (FBLPromise *)onQueue:(dispatch_queue_t)queue
++ (instancetype)onQueue:(dispatch_queue_t)queue
                attempts:(NSInteger)count
                   delay:(NSTimeInterval)interval
               condition:(nullable FBLPromiseRetryPredicateBlock)predicate
@@ -88,7 +88,7 @@ static void FBLPromiseRetryAttempt(FBLPromise *promise, dispatch_queue_t queue, 
   NSParameterAssert(queue);
   NSParameterAssert(work);
 
-  FBLPromise *promise = [[FBLPromise alloc] initPending];
+  FBLPromise *promise = [[self alloc] initPending];
   FBLPromiseRetryAttempt(promise, queue, count, interval, predicate, work);
   return promise;
 }

--- a/Sources/FBLPromises/FBLPromise+Timeout.m
+++ b/Sources/FBLPromises/FBLPromise+Timeout.m
@@ -27,7 +27,7 @@
 - (FBLPromise *)onQueue:(dispatch_queue_t)queue timeout:(NSTimeInterval)interval {
   NSParameterAssert(queue);
 
-  FBLPromise *promise = [[FBLPromise alloc] initPending];
+  FBLPromise *promise = [[[self class] alloc] initPending];
   [self observeOnQueue:queue
       fulfill:^(id __nullable value) {
         [promise fulfill:value];

--- a/Sources/FBLPromises/FBLPromise.m
+++ b/Sources/FBLPromises/FBLPromise.m
@@ -193,7 +193,7 @@ static dispatch_queue_t gFBLPromiseDefaultDispatchQueue;
 
 - (void)addPendingObject:(id)object {
   NSParameterAssert(object);
-  
+
   @synchronized(self) {
     if (_state == FBLPromiseStatePending) {
       if (!_pendingObjects) {
@@ -254,7 +254,7 @@ static dispatch_queue_t gFBLPromiseDefaultDispatchQueue;
                chainedReject:(FBLPromiseChainedRejectBlock)chainedReject {
   NSParameterAssert(queue);
 
-  FBLPromise *promise = [[FBLPromise alloc] initPending];
+  FBLPromise *promise = [[[self class] alloc] initPending];
   __auto_type resolver = ^(id __nullable value) {
     if ([value isKindOfClass:[FBLPromise class]]) {
       [(FBLPromise *)value observeOnQueue:queue

--- a/Sources/FBLPromises/include/FBLPromise+Retry.h
+++ b/Sources/FBLPromises/include/FBLPromise+Retry.h
@@ -40,7 +40,7 @@ typedef BOOL (^FBLPromiseRetryPredicateBlock)(NSInteger, NSError *) NS_SWIFT_UNA
  @return A new pending promise that fulfills with the same value as the promise returned from `work`
          block, or rejects with the same error after all retry attempts have been exhausted.
  */
-+ (FBLPromise *)retry:(FBLPromiseRetryWorkBlock)work NS_SWIFT_UNAVAILABLE("");
++ (instancetype)retry:(FBLPromiseRetryWorkBlock)work NS_SWIFT_UNAVAILABLE("");
 
 /**
  Creates a pending promise that fulfills with the same value as the promise returned from `work`
@@ -55,7 +55,7 @@ typedef BOOL (^FBLPromiseRetryPredicateBlock)(NSInteger, NSError *) NS_SWIFT_UNA
  @return A new pending promise that fulfills with the same value as the promise returned from `work`
          block, or rejects with the same error after all retry attempts have been exhausted.
  */
-+ (FBLPromise *)onQueue:(dispatch_queue_t)queue
++ (instancetype)onQueue:(dispatch_queue_t)queue
                   retry:(FBLPromiseRetryWorkBlock)work NS_SWIFT_UNAVAILABLE("");
 
 /**
@@ -70,7 +70,7 @@ typedef BOOL (^FBLPromiseRetryPredicateBlock)(NSInteger, NSError *) NS_SWIFT_UNA
  @return A new pending promise that fulfills with the same value as the promise returned from `work`
          block, or rejects with the same error after all retry attempts have been exhausted.
  */
-+ (FBLPromise *)attempts:(NSInteger)count
++ (instancetype)attempts:(NSInteger)count
                    retry:(FBLPromiseRetryWorkBlock)work NS_SWIFT_UNAVAILABLE("");
 
 /**
@@ -86,7 +86,7 @@ typedef BOOL (^FBLPromiseRetryPredicateBlock)(NSInteger, NSError *) NS_SWIFT_UNA
  @return A new pending promise that fulfills with the same value as the promise returned from `work`
          block, or rejects with the same error after all retry attempts have been exhausted.
  */
-+ (FBLPromise *)onQueue:(dispatch_queue_t)queue
++ (instancetype)onQueue:(dispatch_queue_t)queue
                attempts:(NSInteger)count
                   retry:(FBLPromiseRetryWorkBlock)work NS_SWIFT_UNAVAILABLE("");
 
@@ -109,7 +109,7 @@ typedef BOOL (^FBLPromiseRetryPredicateBlock)(NSInteger, NSError *) NS_SWIFT_UNA
          block, or rejects with the same error after all retry attempts have been exhausted or if
          the given condition is not met.
  */
-+ (FBLPromise *)attempts:(NSInteger)count
++ (instancetype)attempts:(NSInteger)count
                    delay:(NSTimeInterval)interval
                condition:(nullable FBLPromiseRetryPredicateBlock)predicate
                    retry:(FBLPromiseRetryWorkBlock)work NS_SWIFT_UNAVAILABLE("");
@@ -134,7 +134,7 @@ typedef BOOL (^FBLPromiseRetryPredicateBlock)(NSInteger, NSError *) NS_SWIFT_UNA
          block, or rejects with the same error after all retry attempts have been exhausted or if
          the given condition is not met.
  */
-+ (FBLPromise *)onQueue:(dispatch_queue_t)queue
++ (instancetype)onQueue:(dispatch_queue_t)queue
                attempts:(NSInteger)count
                   delay:(NSTimeInterval)interval
               condition:(nullable FBLPromiseRetryPredicateBlock)predicate


### PR DESCRIPTION
There's a handful of places that use `FBLPromise` that should use `self` or `self class`.

Note that anyplace that checks `isKindOfClass:` I left alone, to let potential subclasses to continue to check against `FBLPromise` and not a subclass.