### PR TITLE
Add public getters for `isPending`, `isFulfilled` and `isRejected`

### DIFF
--- a/Sources/Promises/Promise.swift
+++ b/Sources/Promises/Promise.swift
@@ -76,11 +76,11 @@ public final class Promise<Value> {
   /// Underlying ObjC counterpart.
   let objCPromise: ObjCPromise<AnyObject>
 
-  var isPending: Bool { return objCPromise.__isPending }
+  public var isPending: Bool { return objCPromise.__isPending }
 
-  var isFulfilled: Bool { return objCPromise.__isFulfilled }
+  public var isFulfilled: Bool { return objCPromise.__isFulfilled }
 
-  var isRejected: Bool { return objCPromise.__isRejected }
+  public var isRejected: Bool { return objCPromise.__isRejected }
 
   var value: Value? {
     let objCValue = objCPromise.__value


### PR DESCRIPTION
While writing a unit test in my app, I came across the need to assert the state of a promise. Specifically, I want to assert that a promise is pending. Currently, the `isPending` property has internal access. This pull request simply adds the public modifier to `isPending`, `isFulfilled` and `isRejected` properties of `Promise`.