### PR TITLE
Fix Xcode 14.3 build issue

### DIFF
--- a/PromisesObjC.podspec
+++ b/PromisesObjC.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
                      DESC
 
   s.ios.deployment_target  = '9.0'
-  s.osx.deployment_target  = '10.10'
+  s.osx.deployment_target  = '10.11'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
 

--- a/PromisesSwift.podspec
+++ b/PromisesSwift.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
                      DESC
 
   s.ios.deployment_target  = '9.0'
-  s.osx.deployment_target  = '10.10'
+  s.osx.deployment_target  = '10.11'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
   s.swift_versions = ['5.0', '5.2']


### PR DESCRIPTION
Xcode 14.3 does not support building for a minimum macOS target of 10.10.

More context at https://stackoverflow.com/questions/75574268/missing-file-libarclite-iphoneos-a-xcode-14-3