### PR TITLE
Update Promise.swift with convenience init to create pending promise

### DIFF
--- a/Sources/Promises/Promise.swift
+++ b/Sources/Promises/Promise.swift
@@ -31,6 +31,11 @@ public final class Promise<Value> {
     return Promise<Value>.init(ObjCPromise<AnyObject>.__pending())
   }
 
+  /// Creates a new pending promise.
+  public convenience init() {
+    self.init(ObjCPromise<AnyObject>.__pending())
+  }
+
   /// Creates a new promise rejected with the given `error`.
   public convenience init(_ error: Error) {
     self.init(ObjCPromise<AnyObject>.__resolved(with: error as NSError))


### PR DESCRIPTION
Created convenience init to initiate a pending promise.  This will make fake gens easier without having to create a new Default Value anymore.