### PR TITLE
Update return type to work around kotlin compiler error.

### DIFF
--- a/Sources/FBLPromises/FBLPromise.m
+++ b/Sources/FBLPromises/FBLPromise.m
@@ -284,13 +284,13 @@ static dispatch_queue_t gFBLPromiseDefaultDispatchQueue;
 
 @implementation FBLPromise (DotSyntaxAdditions)
 
-+ (instancetype (^)(void))pending {
++ (FBLPromise * (^)(void))pending {
   return ^(void) {
     return [self pendingPromise];
   };
 }
 
-+ (instancetype (^)(id __nullable))resolved {
++ (FBLPromise * (^)(id __nullable))resolved {
   return ^(id resolution) {
     return [self resolvedWith:resolution];
   };

--- a/Sources/FBLPromises/include/FBLPromise.h
+++ b/Sources/FBLPromises/include/FBLPromise.h
@@ -85,8 +85,8 @@ NS_ASSUME_NONNULL_BEGIN
         FBLPromise.resolved(value)
 
  */
-+ (instancetype (^)(void))pending FBL_PROMISES_DOT_SYNTAX NS_SWIFT_UNAVAILABLE("");
-+ (instancetype (^)(id __nullable))resolved FBL_PROMISES_DOT_SYNTAX NS_SWIFT_UNAVAILABLE("");
++ (FBLPromise * (^)(void))pending FBL_PROMISES_DOT_SYNTAX NS_SWIFT_UNAVAILABLE("");
++ (FBLPromise * (^)(id __nullable))resolved FBL_PROMISES_DOT_SYNTAX NS_SWIFT_UNAVAILABLE("");
 
 @end
 


### PR DESCRIPTION
See https://youtrack.jetbrains.com/issue/KT-59597/KN-Usage-of-instancetype-in-block-return-type-crashes for context.

When a method has a return type which is a block that returns instancetype, the compiler fails.