### PR TITLE
Make dealloc test pass when compiled in opt mode

### DIFF
--- a/Tests/FBLPromisesTests/FBLPromiseTests.m
+++ b/Tests/FBLPromisesTests/FBLPromiseTests.m
@@ -212,7 +212,8 @@
 
   @autoreleasepool {
     XCTAssertNil(weakPromise);
-    weakPromise = [FBLPromise pendingPromise];
+    FBLPromise *promise = [FBLPromise pendingPromise];
+    weakPromise = promise;
     XCTAssertNotNil(weakPromise);
   }
   XCTAssertNil(weakPromise);


### PR DESCRIPTION
This reverts a change to the test made in https://github.com/google/promises/commit/0e9e9e39d83f7a479188240d381fd25b5834627c 

The original change appears to have been intended as a cleanup for another type of dealloc test and may have still passed in dbg mode, but would not pass in opt mode.