### PR TITLE
Rename generic to avoid shadowing error

### DIFF
--- a/Sources/Promises/Promise+Do.swift
+++ b/Sources/Promises/Promise+Do.swift
@@ -16,19 +16,19 @@ import Foundation
 
 public extension Promise {
   // swiftlint:disable:next type_name
-  typealias Do<Value> = () throws -> Value
+  typealias Do<T> = () throws -> T
 
   /// Creates a pending promise to be resolved with the return value of `work` block which is
   /// executed asynchronously on the given `queue`.
   /// - parameters:
   ///   - queue: A queue to invoke the `work` block on.
   ///   - work: A block that returns a value used to resolve the new promise.
-  convenience init<Value>(on queue: DispatchQueue = .promises, _ work: @escaping Do<Value>) {
+  convenience init<T>(on queue: DispatchQueue = .promises, _ work: @escaping Do<T>) {
     let objCPromise = ObjCPromise<AnyObject>.__onQueue(queue) {
       do {
         let resolution = try work()
         return type(of: resolution) is NSError.Type
-          ? resolution as! NSError : Promise<Value>.asAnyObject(resolution)
+          ? resolution as! NSError : Promise<T>.asAnyObject(resolution)
       } catch let error {
         return error as NSError
       }
@@ -43,9 +43,9 @@ public extension Promise {
   /// - parameters:
   ///   - queue: A queue to invoke the `work` block on.
   ///   - work: A block that returns a promise used to resolve the new promise.
-  convenience init<Value>(
+  convenience init<T>(
     on queue: DispatchQueue = .promises,
-    _ work: @escaping Do<Promise<Value>>
+    _ work: @escaping Do<Promise<T>>
   ) {
     let objCPromise = ObjCPromise<AnyObject>.__onQueue(queue) {
       do {

--- a/Sources/Promises/Promise.swift
+++ b/Sources/Promises/Promise.swift
@@ -16,12 +16,12 @@ import FBLPromises
 
 /// Promises synchronization construct in Swift. Leverages ObjC implementation internally.
 public final class Promise<Value> {
-  public typealias ObjCPromise<Value: AnyObject> = FBLPromise<Value>
+  public typealias ObjCPromise<T: AnyObject> = FBLPromise<T>
 
   /// Creates a new promise with an existing ObjC promise.
-  public init<Value>(_ objCPromise: ObjCPromise<Value>) {
+  public init<T>(_ objCPromise: ObjCPromise<T>) {
     guard let objCPromise = objCPromise as? ObjCPromise<AnyObject> else {
-      preconditionFailure("Cannot cast \(Value.self) to \(AnyObject.self)")
+      preconditionFailure("Cannot cast \(T.self) to \(AnyObject.self)")
     }
     self.objCPromise = objCPromise
   }
@@ -69,9 +69,9 @@ public final class Promise<Value> {
   }
 
   /// Converts `self` into ObjC promise.
-  public func asObjCPromise<Value>() -> ObjCPromise<Value> {
-    guard let objCPromise = objCPromise as? ObjCPromise<Value> else {
-      preconditionFailure("Cannot cast \(AnyObject.self) to \(Value.self)")
+  public func asObjCPromise<T>() -> ObjCPromise<T> {
+    guard let objCPromise = objCPromise as? ObjCPromise<T> else {
+      preconditionFailure("Cannot cast \(AnyObject.self) to \(T.self)")
     }
     return objCPromise
   }


### PR DESCRIPTION
When building with the latest upstream Swift I get several errors like:
```
src/Sources/Promises/Promise.swift:19:32: error: generic parameter 'Value' shadows generic parameter from outer scope with the same name; this is an error in Swift 6
  public typealias ObjCPromise<Value: AnyObject> = FBLPromise<Value>
                               ^
src/Sources/Promises/Promise.swift:18:28: note: 'Value' previously declared here
public final class Promise<Value> {
                           ^
```

This pull request should fix these errors (with no functional changes) by renaming the shadowing generics.