### PR TITLE
Fix SwiftUI previews crashes when Promises is statically linked.

### DIFF
--- a/Sources/FBLPromises/FBLPromise+All.m
+++ b/Sources/FBLPromises/FBLPromise+All.m
@@ -84,3 +84,6 @@
 }
 
 @end
+
+/** Stub used to force the linker to include the categories in this file. */
+void FBLIncludeAllCategory(void) {}

--- a/Sources/FBLPromises/FBLPromise+Always.m
+++ b/Sources/FBLPromises/FBLPromise+Always.m
@@ -56,3 +56,6 @@
 }
 
 @end
+
+/** Stub used to force the linker to include the categories in this file. */
+void FBLIncludeAlwaysCategory(void) {}

--- a/Sources/FBLPromises/FBLPromise+Any.m
+++ b/Sources/FBLPromises/FBLPromise+Any.m
@@ -110,3 +110,6 @@ static NSArray *FBLPromiseCombineValuesAndErrors(NSArray<FBLPromise *> *promises
 }
 
 @end
+
+/** Stub used to force the linker to include the categories in this file. */
+void FBLIncludeAnyCategory(void) {}

--- a/Sources/FBLPromises/FBLPromise+Async.m
+++ b/Sources/FBLPromises/FBLPromise+Async.m
@@ -68,3 +68,6 @@
 }
 
 @end
+
+/** Stub used to force the linker to include the categories in this file. */
+void FBLIncludeAsyncCategory(void) {}

--- a/Sources/FBLPromises/FBLPromise+Await.m
+++ b/Sources/FBLPromises/FBLPromise+Await.m
@@ -46,3 +46,6 @@ id __nullable FBLPromiseAwait(FBLPromise *promise, NSError **outError) {
   }
   return resolution;
 }
+
+/** Stub used to force the linker to include the categories in this file. */
+void FBLIncludeAwaitCategory(void) {}

--- a/Sources/FBLPromises/FBLPromise+Catch.m
+++ b/Sources/FBLPromises/FBLPromise+Catch.m
@@ -53,3 +53,6 @@
 }
 
 @end
+
+/** Stub used to force the linker to include the categories in this file. */
+void FBLIncludeCatchCategory(void) {}

--- a/Sources/FBLPromises/FBLPromise+Delay.m
+++ b/Sources/FBLPromises/FBLPromise+Delay.m
@@ -57,3 +57,6 @@
 }
 
 @end
+
+/** Stub used to force the linker to include the categories in this file. */
+void FBLIncludeDelayCategory(void) {}

--- a/Sources/FBLPromises/FBLPromise+Do.m
+++ b/Sources/FBLPromises/FBLPromise+Do.m
@@ -57,3 +57,6 @@
 }
 
 @end
+
+/** Stub used to force the linker to include the categories in this file. */
+void FBLIncludeDoCategory(void) {}

--- a/Sources/FBLPromises/FBLPromise+Race.m
+++ b/Sources/FBLPromises/FBLPromise+Race.m
@@ -63,3 +63,6 @@
 }
 
 @end
+
+/** Stub used to force the linker to include the categories in this file. */
+void FBLIncludeRaceCategory(void) {}

--- a/Sources/FBLPromises/FBLPromise+Recover.m
+++ b/Sources/FBLPromises/FBLPromise+Recover.m
@@ -52,3 +52,6 @@
 }
 
 @end
+
+/** Stub used to force the linker to include the categories in this file. */
+void FBLIncludeRecoverCategory(void) {}

--- a/Sources/FBLPromises/FBLPromise+Reduce.m
+++ b/Sources/FBLPromises/FBLPromise+Reduce.m
@@ -59,3 +59,6 @@
 }
 
 @end
+
+/** Stub used to force the linker to include the categories in this file. */
+void FBLIncludeReduceCategory(void) {}

--- a/Sources/FBLPromises/FBLPromise+Retry.m
+++ b/Sources/FBLPromises/FBLPromise+Retry.m
@@ -126,3 +126,6 @@ static void FBLPromiseRetryAttempt(FBLPromise *promise, dispatch_queue_t queue, 
 }
 
 @end
+
+/** Stub used to force the linker to include the categories in this file. */
+void FBLIncludeRetryCategory(void) {}

--- a/Sources/FBLPromises/FBLPromise+Then.m
+++ b/Sources/FBLPromises/FBLPromise+Then.m
@@ -48,3 +48,6 @@
 }
 
 @end
+
+/** Stub used to force the linker to include the categories in this file. */
+void FBLIncludeThenCategory(void) {}

--- a/Sources/FBLPromises/FBLPromise+Timeout.m
+++ b/Sources/FBLPromises/FBLPromise+Timeout.m
@@ -62,3 +62,6 @@
 }
 
 @end
+
+/** Stub used to force the linker to include the categories in this file. */
+void FBLIncludeTimeoutCategory(void) {}

--- a/Sources/FBLPromises/FBLPromise+Validate.m
+++ b/Sources/FBLPromises/FBLPromise+Validate.m
@@ -54,3 +54,6 @@
 }
 
 @end
+
+/** Stub used to force the linker to include the categories in this file. */
+void FBLIncludeValidateCategory(void) {}

--- a/Sources/FBLPromises/FBLPromise+Wrap.m
+++ b/Sources/FBLPromises/FBLPromise+Wrap.m
@@ -418,3 +418,6 @@
 }
 
 @end
+
+/** Stub used to force the linker to include the categories in this file. */
+void FBLIncludeWrapCategory(void) {}

--- a/Sources/FBLPromises/FBLPromise.m
+++ b/Sources/FBLPromises/FBLPromise.m
@@ -280,6 +280,51 @@ static dispatch_queue_t gFBLPromiseDefaultDispatchQueue;
   return promise;
 }
 
+#pragma mark - Category linking workaround
+
+extern void FBLIncludeAllCategory(void);
+extern void FBLIncludeAlwaysCategory(void);
+extern void FBLIncludeAnyCategory(void);
+extern void FBLIncludeAsyncCategory(void);
+extern void FBLIncludeAwaitCategory(void);
+extern void FBLIncludeCatchCategory(void);
+extern void FBLIncludeDelayCategory(void);
+extern void FBLIncludeDoCategory(void);
+extern void FBLIncludeRaceCategory(void);
+extern void FBLIncludeRecoverCategory(void);
+extern void FBLIncludeReduceCategory(void);
+extern void FBLIncludeRetryCategory(void);
+extern void FBLIncludeThenCategory(void);
+extern void FBLIncludeTimeoutCategory(void);
+extern void FBLIncludeValidateCategory(void);
+extern void FBLIncludeWrapCategory(void);
+
+/**
+ Does nothing when called, and not meant to be called.
+ 
+ This method forces the linker to include all FBLPromise categories even if
+ users do not include the '-ObjC' linker flag in their projects.
+ */
++ (void)noop {
+  FBLIncludeAllCategory();
+  FBLIncludeAllCategory();
+  FBLIncludeAlwaysCategory();
+  FBLIncludeAnyCategory();
+  FBLIncludeAsyncCategory();
+  FBLIncludeAwaitCategory();
+  FBLIncludeCatchCategory();
+  FBLIncludeDelayCategory();
+  FBLIncludeDoCategory();
+  FBLIncludeRaceCategory();
+  FBLIncludeRecoverCategory();
+  FBLIncludeReduceCategory();
+  FBLIncludeRetryCategory();
+  FBLIncludeThenCategory();
+  FBLIncludeTimeoutCategory();
+  FBLIncludeValidateCategory();
+  FBLIncludeWrapCategory();
+}
+
 @end
 
 @implementation FBLPromise (DotSyntaxAdditions)


### PR DESCRIPTION
Targets #189 by applying the fix suggested in https://github.com/google/promises/issues/189#issue-1275085478