### PR TITLE
[Promises] Force-link 'FBLPromises+Testing.m'

### DIFF
--- a/Sources/FBLPromises/FBLPromise+Testing.m
+++ b/Sources/FBLPromises/FBLPromise+Testing.m
@@ -53,3 +53,6 @@ BOOL FBLWaitForPromisesWithTimeout(NSTimeInterval timeout) {
 }
 
 @end
+
+/** Stub used to force the linker to include the categories in this file. */
+void FBLIncludeTestingCategory(void) {}

--- a/Sources/FBLPromises/FBLPromise.m
+++ b/Sources/FBLPromises/FBLPromise.m
@@ -298,6 +298,7 @@ extern void FBLIncludeThenCategory(void);
 extern void FBLIncludeTimeoutCategory(void);
 extern void FBLIncludeValidateCategory(void);
 extern void FBLIncludeWrapCategory(void);
+extern void FBLIncludeTestingCategory(void);
 
 /**
  Does nothing when called, and not meant to be called.
@@ -323,6 +324,7 @@ extern void FBLIncludeWrapCategory(void);
   FBLIncludeTimeoutCategory();
   FBLIncludeValidateCategory();
   FBLIncludeWrapCategory();
+  FBLIncludeTestingCategory();
 }
 
 @end

--- a/Sources/FBLPromises/FBLPromise.m
+++ b/Sources/FBLPromises/FBLPromise.m
@@ -294,11 +294,11 @@ extern void FBLIncludeRaceCategory(void);
 extern void FBLIncludeRecoverCategory(void);
 extern void FBLIncludeReduceCategory(void);
 extern void FBLIncludeRetryCategory(void);
+extern void FBLIncludeTestingCategory(void);
 extern void FBLIncludeThenCategory(void);
 extern void FBLIncludeTimeoutCategory(void);
 extern void FBLIncludeValidateCategory(void);
 extern void FBLIncludeWrapCategory(void);
-extern void FBLIncludeTestingCategory(void);
 
 /**
  Does nothing when called, and not meant to be called.
@@ -320,11 +320,11 @@ extern void FBLIncludeTestingCategory(void);
   FBLIncludeRecoverCategory();
   FBLIncludeReduceCategory();
   FBLIncludeRetryCategory();
+  FBLIncludeTestingCategory();
   FBLIncludeThenCategory();
   FBLIncludeTimeoutCategory();
   FBLIncludeValidateCategory();
   FBLIncludeWrapCategory();
-  FBLIncludeTestingCategory();
 }
 
 @end


### PR DESCRIPTION
Follow-up to #221. @paulb777 found that we need to also force-link `Sources/FBLPromises/FBLPromise+Testing.m` to include it's `dispatchGroup` implementation.