### PR TITLE
fix: add explicit platform versions to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,12 @@ import PackageDescription
 
 let package = Package(
   name: "Promises",
+  platforms: [
+    .iOS(.v9),
+    .macOS(.v10_11),
+    .tvOS(.v9),
+    .watchOS(.v2)
+  ],
   products: [
     .library(
       name: "FBLPromises",


### PR DESCRIPTION
nanopb fix for https://github.com/firebase/firebase-ios-sdk/issues/16244

The Package.swift did not provide an explicit [`platforms: [SupportedPlatform]?`](https://developer.apple.com/documentation/packagedescription/package/platforms). On Xcode 27 beta, this caused watchOS builds to fail. Only watchOS seems to be affected by not being specified in the platforms array.:
```console
/Users/nickcooke/Library/Developer/Xcode/DerivedData/app-check-bazhoueefjmiowavinzydkvkoqvm/SourcePackages/checkouts/promises/Package.swift: error: The watchOS Simulator deployment target 'WATCHOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 27.0.x. (in target 'Promises' from project 'Promises' at path '/Users/nickcooke/Library/Developer/Xcode/DerivedData/app-check-bazhoueefjmiowavinzydkvkoqvm/SourcePackages/checkouts/promises/Package.swift')
```

Perhaps we should be setting `watchOS(.v9)` as we are explicitly specifying a version out of the logged range, but this would violate Firebase's currently watchOS min. supported version.

Observations:
- watchOS is the only platform complaining about the missing specifier
- adding the non-watchOS platforms is not necessary for those respective platforms to build
  - to future proof, I'm adding an explicit platforms array with all supported versions
    - this package's swift tools version does not support visionOS or macCatalyst specifiers
      -  building visionOS 27 does however pass
      -  building macCatalyst 26.5 with Xcode 27 passes (do not have beta macOS installed so can't test macCatalyst 27)

Mirroring the platform support versions from the promises podspec:
From https://github.com/google/promises/blob/d6d659a6cbdd4108788781d178a72fd34ce07e6e/PromisesSwift.podspec#L19-L23
```ruby
  s.ios.deployment_target  = '9.0'
  s.osx.deployment_target  = '10.11'
  s.tvos.deployment_target = '9.0'
  s.watchos.deployment_target = '2.0'
  s.visionos.deployment_target = '1.0'
```


### Versioning
We should tag this version as a patch release: 2.4**.1**, so existing Firebase versions pick this up.

https://github.com/firebase/firebase-ios-sdk/blob/7f9f7d761627c827a0c6d7a410c9a111bf220f18/Package.swift#L136-L139
```swift
   .package(
      url: "https://github.com/google/promises.git",
      "2.4.0" ..< "3.0.0"
    ),
```
