### PR TITLE
infra: bump podspecs for 2.4.1 release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,14 +17,25 @@ jobs:
       - name: Test
         run: swift test
 
-  cocoapods:
+  cocoapods-objc:
     strategy:
       matrix:
-        podspec: [PromisesObjC.podspec, PromisesSwift.podspec]
         platform: [ios, tvos, macos, watchos]
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v4
       - name: Lint
         run: |
-          pod lib lint ${{ matrix.podspec }} --platforms=${{ matrix.platform }}
+          pod lib lint PromisesObjC.podspec --platforms=${{ matrix.platform }}
+
+
+  cocoapods-swift:
+    strategy:
+      matrix:
+        platform: [ios, tvos, macos, watchos]
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint
+        run: |
+          pod lib lint PromisesSwift.podspec --platforms=${{ matrix.platform }} --include-podspecs=PromisesObjC.podspec

--- a/PromisesObjC.podspec
+++ b/PromisesObjC.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = 'PromisesObjC'
-  s.version     = '2.4.0'
+  s.version     = '2.4.1'
   s.authors     = 'Google Inc.'
   s.license     = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.homepage    = 'https://github.com/google/promises'

--- a/PromisesSwift.podspec
+++ b/PromisesSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = 'PromisesSwift'
-  s.version     = '2.4.0'
+  s.version     = '2.4.1'
   s.authors     = 'Google Inc.'
   s.license     = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.homepage    = 'https://github.com/google/promises'


### PR DESCRIPTION
Upon merge, I will:
- publish 2.4.1 tag (releases for SPM)
- publish the podspecs
- make a github release page